### PR TITLE
Publish Nuget to ADO artifacts

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,62 @@
+﻿# Publish CoreLib and Client Lib to ADO feed
+name: Publish CoreLib and Client Lib to ADO feed
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: ['7.0.x']
+
+    environment: publish-sm-preview-packages-to-ado
+
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          clean: true
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+          source-url: ${{ secrets.AZURE_ARTIFACTS_FEED_URL }}
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.AZURE_DEVOPS_PAT }}
+
+      - name: Show Run and Attempt IDs
+        run: |
+          echo "Run ID: ${{ github.run_number }}"
+          echo "Attempt ID: ${{ github.run_attempt }}"
+          echo "Version: 0.0.${{ github.run_number }}.${{ github.run_attempt }}"
+          echo "VersionPrefix=0.0.${{ github.run_number }}.${{ github.run_attempt }}" >> $GITHUB_ENV
+
+      - name: Build and pack Client NuGet package
+        run: |
+          dotnet pack dotnet/ClientLib/ClientLib.csproj \
+            -c Release \
+            -v normal \
+            --version-suffix preview \
+            -p:VersionPrefix=${{ env.VersionPrefix }} \
+            --output dotnet/ClientLib/bin/Release
+
+      - name: Build and pack Core NuGet package
+        run: |
+          dotnet pack dotnet/CoreLib/CoreLib.csproj \
+            -c Release \
+            -v normal \
+            --version-suffix preview \
+            -p:VersionPrefix=${{ env.VersionPrefix }} \
+            --output dotnet/CoreLib/bin/Release
+
+      - name: Push Client NuGet package to ADO feed
+        run: dotnet nuget push dotnet/ClientLib/bin/Release/*.nupkg --api-key az
+
+      - name: Push Core NuGet package to ADO feed
+        run: dotnet nuget push dotnet/CoreLib/bin/Release/*.nupkg --api-key az

--- a/dotnet/ClientLib/ClientLib.csproj
+++ b/dotnet/ClientLib/ClientLib.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>Microsoft.SemanticMemory.Client</AssemblyName>
         <RootNamespace>Microsoft.SemanticMemory.Client</RootNamespace>
+        <IsPackable>true</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/dotnet/CoreLib/CoreLib.csproj
+++ b/dotnet/CoreLib/CoreLib.csproj
@@ -6,6 +6,7 @@
         <AssemblyName>Microsoft.SemanticMemory.Core</AssemblyName>
         <RootNamespace>Microsoft.SemanticMemory.Core</RootNamespace>
         <NoWarn>CA1711,CA1724,CA1308</NoWarn>
+        <IsPackable>true</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
Temporary solution to publish CoreLib and ClientLib to Azure DevOps Artifacts Feed for internal consumption.
Will publish to a public feed/registry when ready.

## High level description (Approach, Design)
Package names:
Microsoft.SemanticMemory.Core
Microsoft.SemanticMemory.Client

Versioning:
0.0.[RunId].[AttemptId]-preview
