### PR TITLE
Expose memories

### DIFF
--- a/dotnet/CoreLib/AppBuilders/DependencyInjection.cs
+++ b/dotnet/CoreLib/AppBuilders/DependencyInjection.cs
@@ -32,6 +32,7 @@ public static partial class DependencyInjection
     public static void ConfigureRuntime(this IServiceCollection services, SemanticMemoryConfig config)
     {
         services.AddSingleton<SemanticMemoryConfig>(config);
+        services.AddSingleton<MemoryClient, MemoryClient>();
         services.AddSingleton<SearchClient, SearchClient>();
         services.AddSingleton<IMimeTypeDetection, MimeTypesDetection>();
 

--- a/dotnet/CoreLib/Search/MemoryClient.cs
+++ b/dotnet/CoreLib/Search/MemoryClient.cs
@@ -110,6 +110,8 @@ public class MemoryClient
                     LastUpdate = lastUpdate,
                 };
 
+            citation.Partitions.Add(partition);
+
             yield return (citation, partition);
         }
     }

--- a/dotnet/CoreLib/Search/MemoryClient.cs
+++ b/dotnet/CoreLib/Search/MemoryClient.cs
@@ -106,11 +106,9 @@ public class MemoryClient
                 {
                     Text = partitionText,
                     Relevance = Convert.ToSingle(relevance),
-                    SizeInTokens = 0, // TODO: from metadata
+                    SizeInTokens = 0, // TODO: from metadata (or devis mentioned to be removed)
                     LastUpdate = lastUpdate,
                 };
-
-            citation.Partitions.Add(partition);
 
             yield return (citation, partition);
         }

--- a/dotnet/CoreLib/Search/MemoryClient.cs
+++ b/dotnet/CoreLib/Search/MemoryClient.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel.AI.Embeddings;
+using Microsoft.SemanticMemory.Client;
+using Microsoft.SemanticMemory.Client.Models;
+using Microsoft.SemanticMemory.Core.Diagnostics;
+using Microsoft.SemanticMemory.Core.MemoryStorage;
+
+namespace Microsoft.SemanticMemory.Core.Search;
+
+public class MemoryClient
+{
+    private readonly ISemanticMemoryVectorDb _vectorDb;
+    private readonly ITextEmbeddingGeneration _embeddingGenerator;
+    private readonly ILogger<MemoryClient> _log;
+
+    public MemoryClient(
+        ISemanticMemoryVectorDb vectorDb,
+        ITextEmbeddingGeneration embeddingGenerator,
+        ILogger<MemoryClient>? log = null)
+    {
+        this._vectorDb = vectorDb ?? throw new SemanticMemoryException("Search vector DB not configured"); ;
+        this._embeddingGenerator = embeddingGenerator ?? throw new SemanticMemoryException("Embedding generator not configured"); ;
+        this._log = log ?? DefaultLogger<MemoryClient>.Instance;
+    }
+
+    public async IAsyncEnumerable<(MemoryAnswer.Citation, MemoryAnswer.Citation.Partition)> QueryMemoryAsync(
+        string query,
+        string indexName,
+        float minSimilarity,
+        int maxMatches,
+        [EnumeratorCancellation]
+        CancellationToken cancellationToken)
+    {
+        var embedding = await this.GenerateEmbeddingAsync(query).ConfigureAwait(false);
+
+        this._log.LogTrace("Fetching relevant memories");
+        var matches = this._vectorDb.GetNearestMatchesAsync(
+            indexName, embedding, maxMatches, minSimilarity, withEmbeddings: false, cancellationToken);
+
+        var memories = new Dictionary<string, MemoryAnswer.Citation>();
+
+        await foreach ((MemoryRecord Record, double Similarity) memory in matches.WithCancellation(cancellationToken))
+        {
+            if (!memory.Record.Tags.ContainsKey(Constants.ReservedPipelineIdTag))
+            {
+                this._log.LogError("The memory record is missing the '{0}' tag", Constants.ReservedPipelineIdTag);
+            }
+
+            if (!memory.Record.Tags.ContainsKey(Constants.ReservedFileIdTag))
+            {
+                this._log.LogError("The memory record is missing the '{0}' tag", Constants.ReservedFileIdTag);
+            }
+
+            if (!memory.Record.Tags.ContainsKey(Constants.ReservedFileTypeTag))
+            {
+                this._log.LogError("The memory record is missing the '{0}' tag", Constants.ReservedFileTypeTag);
+            }
+
+            // Note: a document can be composed by multiple files
+            string documentId = memory.Record.Tags[Constants.ReservedPipelineIdTag].FirstOrDefault() ?? string.Empty;
+
+            // Identify the file in case there are multiple files
+            string fileId = memory.Record.Tags[Constants.ReservedFileIdTag].FirstOrDefault() ?? string.Empty;
+
+            string linkToFile = $"{documentId}/{fileId}";
+
+            var partitionText = memory.Record.Metadata["text"].ToString()?.Trim() ?? string.Empty;
+            if (string.IsNullOrEmpty(partitionText))
+            {
+                this._log.LogError("The document partition is empty, user: {0}, doc: {1}", memory.Record.Owner, memory.Record.Id);
+                continue;
+            }
+
+            //// TODO: add file age in days, to push relevance of newer documents
+
+            // If the file is already in the list of citations, only add the partition
+            if (!memories.TryGetValue(linkToFile, out var citation))
+            {
+                string fileContentType = memory.Record.Tags[Constants.ReservedFileTypeTag].FirstOrDefault() ?? string.Empty;
+                string fileName = memory.Record.Metadata["file_name"].ToString() ?? string.Empty;
+
+                citation = new MemoryAnswer.Citation();
+                citation.Link = linkToFile;
+                citation.SourceContentType = fileContentType;
+                citation.SourceName = fileName;
+
+                memories.Add(linkToFile, citation);
+            }
+
+            // Add the partition to the list of citation
+
+#pragma warning disable CA1806 // it's ok if parsing fails
+            DateTimeOffset.TryParse(memory.Record.Metadata["last_update"].ToString(), out var lastUpdate);
+#pragma warning restore CA1806
+
+            var partition =
+                new MemoryAnswer.Citation.Partition
+                {
+                    Text = partitionText,
+                    Relevance = Convert.ToSingle(memory.Similarity),
+                    SizeInTokens = 0, // TODO: from metadata
+                    LastUpdate = lastUpdate,
+                };
+
+            yield return (citation, partition);
+        }
+    }
+
+    private async Task<Embedding<float>> GenerateEmbeddingAsync(string text)
+    {
+        this._log.LogTrace("Generating embedding for the query");
+        IList<Embedding<float>> embeddings = await this._embeddingGenerator
+            .GenerateEmbeddingsAsync(new List<string> { text }).ConfigureAwait(false);
+        if (embeddings.Count == 0)
+        {
+            throw new SemanticMemoryException("Failed to generate embedding for the given question");
+        }
+
+        return embeddings.First();
+    }
+}

--- a/dotnet/CoreLib/SemanticMemoryServerless.cs
+++ b/dotnet/CoreLib/SemanticMemoryServerless.cs
@@ -72,7 +72,7 @@ public class SemanticMemoryServerless : ISemanticMemoryClient
     /// <inheritdoc />
     public Task<MemoryAnswer> AskAsync(string userId, string query, CancellationToken cancellationToken = default)
     {
-        return this._searchClient.SearchAsync(userId: userId, query: query, cancellationToken: cancellationToken);
+        return this._searchClient.AnswerAsync(userId: userId, query: query, cancellationToken: cancellationToken);
     }
 
     /// <inheritdoc />

--- a/dotnet/CoreLib/SemanticMemoryService.cs
+++ b/dotnet/CoreLib/SemanticMemoryService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SemanticMemory.Client.Models;
@@ -29,6 +30,8 @@ public interface ISemanticMemoryService
     Task<DataPipeline?> ReadPipelineStatusAsync(string userId, string documentId, CancellationToken cancellationToken = default);
 
     Task<MemoryAnswer> AskAsync(SearchRequest request, CancellationToken cancellationToken = default);
+
+    Task<IList<(MemoryAnswer.Citation, MemoryAnswer.Citation.Partition)>> SearchAsync(SearchRequest request, CancellationToken cancellationToken = default);
 }
 
 public class SemanticMemoryService : ISemanticMemoryService
@@ -60,6 +63,12 @@ public class SemanticMemoryService : ISemanticMemoryService
 
     ///<inheritdoc />
     public Task<MemoryAnswer> AskAsync(SearchRequest request, CancellationToken cancellationToken = default)
+    {
+        return this._searchClient.AnswerAsync(request, cancellationToken);
+    }
+
+    ///<inheritdoc />
+    public Task<IList<(MemoryAnswer.Citation, MemoryAnswer.Citation.Partition)>> SearchAsync(SearchRequest request, CancellationToken cancellationToken = default)
     {
         return this._searchClient.SearchAsync(request, cancellationToken);
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
SearchClient manages prompt dynamics.  This is incompatible with Copilot Chat which has its own prompt management...as many other applications might.  Copilot Chat requires raw access to memories with citation.

## High level description (Approach, Design)

Extracted MemoryClient from existing SearchClient (more S.O.L.I.D).

![image](https://github.com/microsoft/semantic-memory/assets/66376200/9a7ba251-136b-43f7-bb9b-0a4f572ddcb4)
