### PR TITLE
🔧 Fix directory prompt in InteractiveSetup

### DIFF
--- a/dotnet/InteractiveSetup/Main.cs
+++ b/dotnet/InteractiveSetup/Main.cs
@@ -523,7 +523,7 @@ public static class Main
 
         AppSettings.Change(x => x.Services[ServiceName] = new Dictionary<string, object>
         {
-            { "Directory where to store files", SetupUI.AskOpenQuestion("Directory", config["Directory"].ToString()) }
+            { "Directory", SetupUI.AskOpenQuestion("Directory where to store files", config["Directory"].ToString()) }
         });
     }
 }


### PR DESCRIPTION
 <!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
 The directory prompt in InteractiveSetup was fixed to correctly ask for the directory where files should be stored.

## High level description (Approach, Design)

