### PR TITLE
Reordered null check and step name validation

### DIFF
--- a/dotnet/CoreLib/Pipeline/DistributedPipelineOrchestrator.cs
+++ b/dotnet/CoreLib/Pipeline/DistributedPipelineOrchestrator.cs
@@ -34,14 +34,14 @@ public class DistributedPipelineOrchestrator : BaseOrchestrator
         IPipelineStepHandler handler,
         CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrEmpty(handler.StepName))
-        {
-            throw new ArgumentNullException(nameof(handler.StepName), "The step name is empty");
-        }
-
         if (handler == null)
         {
             throw new ArgumentNullException(nameof(handler), "The handler is NULL");
+        }
+
+        if (string.IsNullOrEmpty(handler.StepName))
+        {
+            throw new ArgumentNullException(nameof(handler.StepName), "The step name is empty");
         }
 
         if (this._queues.ContainsKey(handler.StepName))
@@ -79,14 +79,14 @@ public class DistributedPipelineOrchestrator : BaseOrchestrator
     ///<inheritdoc />
     public override async Task TryAddHandlerAsync(IPipelineStepHandler handler, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrEmpty(handler.StepName))
-        {
-            throw new ArgumentNullException(nameof(handler.StepName), "The step name is empty");
-        }
-
         if (handler == null)
         {
             throw new ArgumentNullException(nameof(handler), "The handler is NULL");
+        }
+
+        if (string.IsNullOrEmpty(handler.StepName))
+        {
+            throw new ArgumentNullException(nameof(handler.StepName), "The step name is empty");
         }
 
         if (this._queues.ContainsKey(handler.StepName)) { return; }

--- a/dotnet/CoreLib/Pipeline/InProcessPipelineOrchestrator.cs
+++ b/dotnet/CoreLib/Pipeline/InProcessPipelineOrchestrator.cs
@@ -29,14 +29,14 @@ public class InProcessPipelineOrchestrator : BaseOrchestrator
         IPipelineStepHandler handler,
         CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrEmpty(handler.StepName))
-        {
-            throw new ArgumentNullException(nameof(handler.StepName), "The step name is empty");
-        }
-
         if (handler == null)
         {
             throw new ArgumentNullException(nameof(handler), "The handler is NULL");
+        }
+
+        if (string.IsNullOrEmpty(handler.StepName))
+        {
+            throw new ArgumentNullException(nameof(handler.StepName), "The step name is empty");
         }
 
         if (this._handlers.ContainsKey(handler.StepName))
@@ -52,14 +52,14 @@ public class InProcessPipelineOrchestrator : BaseOrchestrator
     ///<inheritdoc />
     public override async Task TryAddHandlerAsync(IPipelineStepHandler handler, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrEmpty(handler.StepName))
-        {
-            throw new ArgumentNullException(nameof(handler.StepName), "The step name is empty");
-        }
-
         if (handler == null)
         {
             throw new ArgumentNullException(nameof(handler), "The handler is NULL");
+        }
+
+        if (string.IsNullOrEmpty(handler.StepName))
+        {
+            throw new ArgumentNullException(nameof(handler.StepName), "The step name is empty");
         }
 
         if (this._handlers.ContainsKey(handler.StepName)) { return; }


### PR DESCRIPTION
## Motivation and Context

This pull request improves error handling in the `TryAddHandlerAsync` and `AddHandlerAsync`. Currently, null checks and step name validation need reordering for better reliability.

## High-level Description

I've repositioned null checks for the `handler` parameter to the start of both methods. This ensures `handler` is non-null before accessing properties. Step name validation now follows null checks, maintaining a consistent, safer order.

Please review these changes. 
