### PR TITLE
Update Semantic Kernel to 0.21.230828.2-preview

### DIFF
--- a/dotnet/CoreLib/AI/AzureOpenAI/DependencyInjection.cs
+++ b/dotnet/CoreLib/AI/AzureOpenAI/DependencyInjection.cs
@@ -8,7 +8,6 @@ using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticKernel.Connectors.AI.OpenAI.TextEmbedding;
 using Microsoft.SemanticMemory.AI;
 using Microsoft.SemanticMemory.AI.AzureOpenAI;
-using Microsoft.SemanticMemory.ContentStorage.AzureBlobs;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.SemanticMemory;
@@ -40,7 +39,7 @@ public static partial class DependencyInjection
                         modelId: config.Deployment,
                         endpoint: config.Endpoint,
                         credential: new DefaultAzureCredential(),
-                        logger: serviceProvider.GetService<ILogger<AzureBlobsStorage>>()));
+                        loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
 
             case AzureOpenAIConfig.AuthTypes.APIKey:
                 return services
@@ -48,7 +47,7 @@ public static partial class DependencyInjection
                         modelId: config.Deployment,
                         endpoint: config.Endpoint,
                         apiKey: config.APIKey,
-                        logger: serviceProvider.GetService<ILogger<AzureBlobsStorage>>()));
+                        loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
 
             default:
                 throw new NotImplementedException($"Azure OpenAI auth type '{config.Auth}' not available");

--- a/dotnet/CoreLib/AI/OpenAI/DependencyInjection.cs
+++ b/dotnet/CoreLib/AI/OpenAI/DependencyInjection.cs
@@ -18,7 +18,7 @@ public static partial class MemoryClientBuilderExtensions
             modelId: "text-embedding-ada-002",
             apiKey: apiKey,
             organization: organization,
-            logger: serviceProvider.GetService<ILogger<OpenAITextEmbeddingGeneration>>()));
+            loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
 
         builder.Services.AddSingleton<ITextGeneration>(serviceProvider =>
             new OpenAITextGeneration(new OpenAIConfig
@@ -58,7 +58,7 @@ public static partial class DependencyInjection
                 modelId: config.EmbeddingModel,
                 apiKey: config.APIKey,
                 organization: config.OrgId,
-                logger: serviceProvider.GetService<ILogger<OpenAITextEmbeddingGeneration>>()));
+                loggerFactory: serviceProvider.GetService<ILoggerFactory>()));
     }
 
     public static IServiceCollection AddOpenAITextGeneration(this IServiceCollection services, OpenAIConfig config)

--- a/dotnet/CoreLib/AI/Tokenizers/GPT3/GPT3Settings.cs
+++ b/dotnet/CoreLib/AI/Tokenizers/GPT3/GPT3Settings.cs
@@ -41,7 +41,7 @@ internal static class GPT3Settings
         var encoder = JsonSerializer.Deserialize<Dictionary<string, int>>(json, new JsonSerializerOptions());
 
         return encoder
-               ?? throw new AIException(AIException.ErrorCodes.InvalidConfiguration,
+               ?? throw new AIException(AIException.ErrorCodes.ServiceError,
                    "Encoding table deserialization returned NULL");
     }
 

--- a/dotnet/CoreLib/AI/Tokenizers/GPT3/GPT3Settings.cs
+++ b/dotnet/CoreLib/AI/Tokenizers/GPT3/GPT3Settings.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
-using Microsoft.SemanticKernel.AI;
 
 namespace Microsoft.SemanticMemory.AI.Tokenizers.GPT3;
 
@@ -41,8 +40,7 @@ internal static class GPT3Settings
         var encoder = JsonSerializer.Deserialize<Dictionary<string, int>>(json, new JsonSerializerOptions());
 
         return encoder
-               ?? throw new AIException(AIException.ErrorCodes.ServiceError,
-                   "Encoding table deserialization returned NULL");
+               ?? throw new SemanticMemoryException("Encoding table deserialization returned NULL");
     }
 
     private static Dictionary<Tuple<string, string>, int> DictZip(List<Tuple<string, string>> x, List<int> y)

--- a/dotnet/CoreLib/ContentStorage/EmbeddingFileContent.cs
+++ b/dotnet/CoreLib/ContentStorage/EmbeddingFileContent.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Text.Json.Serialization;
-using Microsoft.SemanticKernel.AI.Embeddings;
+using Microsoft.SemanticMemory.Text;
 
 namespace Microsoft.SemanticMemory.ContentStorage;
 
@@ -26,7 +26,8 @@ public class EmbeddingFileContent
 
     [JsonPropertyName("vector")]
     [JsonPropertyOrder(100)]
-    public Embedding<float> Vector { get; set; }
+    [JsonConverter(typeof(ReadOnlyMemoryConverter))]
+    public ReadOnlyMemory<float> Vector { get; set; }
 
     [JsonPropertyName("timestamp")]
     [JsonPropertyOrder(5)]

--- a/dotnet/CoreLib/CoreLib.csproj
+++ b/dotnet/CoreLib/CoreLib.csproj
@@ -34,7 +34,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SemanticKernel" Version="0.19.230804.2-preview">
+        <PackageReference Include="Microsoft.SemanticKernel" Version="0.21.230828.2-preview">
             <PrivateAssets>none</PrivateAssets>
             <IncludeAssets>all</IncludeAssets>
         </PackageReference>

--- a/dotnet/CoreLib/Handlers/GenerateEmbeddingsHandler.cs
+++ b/dotnet/CoreLib/Handlers/GenerateEmbeddingsHandler.cs
@@ -112,7 +112,7 @@ public class GenerateEmbeddingsHandler : IPipelineStepHandler
                             // TODO: handle Azure.RequestFailedException - BlobNotFound
                             string partitionContent = await this._orchestrator.ReadTextFileAsync(pipeline, partitionFile.Name, cancellationToken).ConfigureAwait(false);
 
-                            IList<Embedding<float>> embedding = await generator.GenerateEmbeddingsAsync(
+                            IList<ReadOnlyMemory<float>> embedding = await generator.GenerateEmbeddingsAsync(
                                 new List<string> { partitionContent }, cancellationToken).ConfigureAwait(false);
 
                             if (embedding.Count == 0)
@@ -121,7 +121,7 @@ public class GenerateEmbeddingsHandler : IPipelineStepHandler
                             }
 
                             embeddingData.Vector = embedding.First();
-                            embeddingData.VectorSize = embeddingData.Vector.Count;
+                            embeddingData.VectorSize = embeddingData.Vector.Length;
                             embeddingData.TimeStamp = DateTimeOffset.UtcNow;
 
                             this._log.LogDebug("Saving embedding file {0}", embeddingFileName);

--- a/dotnet/CoreLib/Handlers/SaveEmbeddingsHandler.cs
+++ b/dotnet/CoreLib/Handlers/SaveEmbeddingsHandler.cs
@@ -76,7 +76,7 @@ public class SaveEmbeddingsHandler : IPipelineStepHandler
                 Vector = embeddingData.Vector,
             };
 
-            // Note that the User Id is not set here, but when mapping MemoryRecord to the specific VectorDB schema 
+            // Note that the User Id is not set here, but when mapping MemoryRecord to the specific VectorDB schema
             record.Tags.Add(Constants.ReservedDocumentIdTag, pipeline.DocumentId);
             record.Tags.Add(Constants.ReservedFileIdTag, embeddingFile.Value.ParentId);
             record.Tags.Add(Constants.ReservedFilePartitionTag, embeddingFile.Value.Id);
@@ -98,7 +98,7 @@ public class SaveEmbeddingsHandler : IPipelineStepHandler
             foreach (ISemanticMemoryVectorDb client in this._vectorDbs)
             {
                 this._log.LogTrace("Creating index '{0}'", pipeline.Index);
-                await client.CreateIndexAsync(pipeline.Index, record.Vector.Count, cancellationToken).ConfigureAwait(false);
+                await client.CreateIndexAsync(pipeline.Index, record.Vector.Length, cancellationToken).ConfigureAwait(false);
 
                 this._log.LogTrace("Saving record {0} in index '{1}'", record.Id, pipeline.Index);
                 await client.UpsertAsync(pipeline.Index, record, cancellationToken).ConfigureAwait(false);

--- a/dotnet/CoreLib/MemoryStorage/AzureCognitiveSearch/AzureCognitiveSearchMemory.cs
+++ b/dotnet/CoreLib/MemoryStorage/AzureCognitiveSearch/AzureCognitiveSearchMemory.cs
@@ -15,7 +15,6 @@ using Azure.Search.Documents.Indexes;
 using Azure.Search.Documents.Indexes.Models;
 using Azure.Search.Documents.Models;
 using Microsoft.Extensions.Logging;
-using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticMemory.Configuration;
 using Microsoft.SemanticMemory.Diagnostics;
 
@@ -99,7 +98,7 @@ public class AzureCognitiveSearchMemory : ISemanticMemoryVectorDb
     /// <inheritdoc />
     public async IAsyncEnumerable<(MemoryRecord, double)> GetSimilarListAsync(
         string indexName,
-        Embedding<float> embedding,
+        ReadOnlyMemory<float> embedding,
         int limit,
         double minRelevanceScore = 0,
         MemoryFilter? filter = null,
@@ -113,7 +112,7 @@ public class AzureCognitiveSearchMemory : ISemanticMemoryVectorDb
         SearchQueryVector vectorQuery = new()
         {
             KNearestNeighborsCount = limit,
-            Value = embedding.Vector.ToList(),
+            Value = embedding.ToArray(),
             Fields = { AzureCognitiveSearchMemoryRecord.VectorField }
         };
 
@@ -219,7 +218,7 @@ public class AzureCognitiveSearchMemory : ISemanticMemoryVectorDb
 
         await foreach (SearchResult<AzureCognitiveSearchMemoryRecord>? doc in searchResult.Value.GetResultsAsync())
         {
-            // stop after returning the amount requested, in case we fetched more to workaround the lack of pre-filtering 
+            // stop after returning the amount requested, in case we fetched more to workaround the lack of pre-filtering
             if (limit-- <= 0) { yield break; }
 
             yield return doc.Document.ToMemoryRecord(withEmbeddings);

--- a/dotnet/CoreLib/MemoryStorage/AzureCognitiveSearch/AzureCognitiveSearchMemoryRecord.cs
+++ b/dotnet/CoreLib/MemoryStorage/AzureCognitiveSearch/AzureCognitiveSearchMemoryRecord.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Microsoft.SemanticKernel.AI.Embeddings;
 
 namespace Microsoft.SemanticMemory.MemoryStorage.AzureCognitiveSearch;
 
@@ -66,7 +65,7 @@ public sealed class AzureCognitiveSearchMemoryRecord
 
         if (withEmbedding)
         {
-            result.Vector = new Embedding<float>(this.Vector);
+            result.Vector = new ReadOnlyMemory<float>(this.Vector);
         }
 
         foreach (string[] keyValue in this.Tags.Select(tag => tag.Split(Constants.ReservedEqualsSymbol, 2)))
@@ -84,7 +83,7 @@ public sealed class AzureCognitiveSearchMemoryRecord
         AzureCognitiveSearchMemoryRecord result = new()
         {
             Id = EncodeId(record.Id),
-            Vector = record.Vector.Vector.ToArray(),
+            Vector = record.Vector.ToArray(),
             Payload = JsonSerializer.Serialize(record.Payload, s_jsonOptions)
         };
 

--- a/dotnet/CoreLib/MemoryStorage/DevTools/SimpleVectorDb.cs
+++ b/dotnet/CoreLib/MemoryStorage/DevTools/SimpleVectorDb.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -7,7 +8,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticKernel.AI.Embeddings.VectorOperations;
 using Microsoft.SemanticMemory.Diagnostics;
 
@@ -54,7 +54,7 @@ public class SimpleVectorDb : ISemanticMemoryVectorDb
     /// <inheritdoc />
     public async IAsyncEnumerable<(MemoryRecord, double)> GetSimilarListAsync(
         string indexName,
-        Embedding<float> embedding,
+        ReadOnlyMemory<float> embedding,
         int limit,
         double minRelevanceScore = 0,
         MemoryFilter? filter = null,
@@ -75,7 +75,7 @@ public class SimpleVectorDb : ISemanticMemoryVectorDb
         var distances = new Dictionary<string, double>();
         foreach (var record in records)
         {
-            var similarity = embedding.Vector.ToArray().CosineSimilarity(record.Value.Vector.Vector.ToArray());
+            var similarity = embedding.ToArray().CosineSimilarity(record.Value.Vector.ToArray());
             distances[record.Value.Id] = similarity;
         }
 

--- a/dotnet/CoreLib/MemoryStorage/ISemanticMemoryVectorDb.cs
+++ b/dotnet/CoreLib/MemoryStorage/ISemanticMemoryVectorDb.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.SemanticKernel.AI.Embeddings;
 
 namespace Microsoft.SemanticMemory.MemoryStorage;
 
@@ -66,7 +66,7 @@ public interface ISemanticMemoryVectorDb
     /// <returns>List of similar vectors, starting from the most similar</returns>
     IAsyncEnumerable<(MemoryRecord, double)> GetSimilarListAsync(
         string indexName,
-        Embedding<float> embedding,
+        ReadOnlyMemory<float> embedding,
         int limit,
         double minRelevanceScore = 0,
         MemoryFilter? filter = null,

--- a/dotnet/CoreLib/MemoryStorage/MemoryRecord.cs
+++ b/dotnet/CoreLib/MemoryStorage/MemoryRecord.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System;
 using System.Collections.Generic;
-using Microsoft.SemanticKernel.AI.Embeddings;
 
 namespace Microsoft.SemanticMemory.MemoryStorage;
 
@@ -15,7 +15,7 @@ public class MemoryRecord
     /// <summary>
     /// Embedding vector
     /// </summary>
-    public Embedding<float> Vector { get; set; } = new();
+    public ReadOnlyMemory<float> Vector { get; set; } = new();
 
     /// <summary>
     /// Optional Searchable Key=Value tags (string => string[] collection)

--- a/dotnet/CoreLib/MemoryStorage/Qdrant/Client/Http/HttpRequest.cs
+++ b/dotnet/CoreLib/MemoryStorage/Qdrant/Client/Http/HttpRequest.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using Microsoft.SemanticMemory.Text;
 
 namespace Microsoft.SemanticMemory.MemoryStorage.Qdrant.Client.Http;
 

--- a/dotnet/CoreLib/MemoryStorage/Qdrant/Client/QdrantPoint.cs
+++ b/dotnet/CoreLib/MemoryStorage/Qdrant/Client/QdrantPoint.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Microsoft.SemanticKernel.AI.Embeddings;
+using Microsoft.SemanticMemory.Text;
 
 namespace Microsoft.SemanticMemory.MemoryStorage.Qdrant.Client;
 
@@ -24,6 +24,7 @@ internal class QdrantPoint<T> where T : DefaultQdrantPayload, new()
     [JsonPropertyName(QdrantConstants.PointPayloadField)]
     public T Payload { get; set; } = new();
 
+    [Obsolete]
     public MemoryRecord ToMemoryRecord(bool withEmbedding = true)
     {
         MemoryRecord result = new()
@@ -35,7 +36,7 @@ internal class QdrantPoint<T> where T : DefaultQdrantPayload, new()
 
         if (withEmbedding)
         {
-            result.Vector = new Embedding<float>(this.Vector.ToArray());
+            result.Vector = new ReadOnlyMemory<float>(this.Vector.ToArray());
         }
 
         foreach (string[] keyValue in this.Payload.Tags.Select(tag => tag.Split(Constants.ReservedEqualsSymbol, 2)))
@@ -52,7 +53,7 @@ internal class QdrantPoint<T> where T : DefaultQdrantPayload, new()
     {
         return new QdrantPoint<T>
         {
-            Vector = record.Vector.Vector.ToArray(),
+            Vector = record.Vector.ToArray(),
             Payload = new T
             {
                 Id = record.Id,

--- a/dotnet/CoreLib/MemoryStorage/Qdrant/QdrantMemory.cs
+++ b/dotnet/CoreLib/MemoryStorage/Qdrant/QdrantMemory.cs
@@ -7,7 +7,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticMemory.Diagnostics;
 using Microsoft.SemanticMemory.MemoryStorage.Qdrant.Client;
 
@@ -93,7 +92,7 @@ public class QdrantMemory : ISemanticMemoryVectorDb
     /// <inheritdoc />
     public async IAsyncEnumerable<(MemoryRecord, double)> GetSimilarListAsync(
         string indexName,
-        Embedding<float> embedding,
+        ReadOnlyMemory<float> embedding,
         int limit,
         double minRelevanceScore = 0,
         MemoryFilter? filter = null,
@@ -109,7 +108,7 @@ public class QdrantMemory : ISemanticMemoryVectorDb
 
         List<(QdrantPoint<DefaultQdrantPayload>, double)> results = await this._qdrantClient.GetSimilarListAsync(
             collectionName: indexName,
-            target: embedding.Vector.ToArray(),
+            target: embedding.ToArray(),
             minSimilarityScore: minRelevanceScore,
             requiredTags: requiredTags,
             limit: limit,

--- a/dotnet/CoreLib/Search/SearchClient.cs
+++ b/dotnet/CoreLib/Search/SearchClient.cs
@@ -285,10 +285,10 @@ public class SearchClient
         return answer;
     }
 
-    private async Task<Embedding<float>> GenerateEmbeddingAsync(string text)
+    private async Task<ReadOnlyMemory<float>> GenerateEmbeddingAsync(string text)
     {
         this._log.LogTrace("Generating embedding for the query");
-        IList<Embedding<float>> embeddings = await this._embeddingGenerator
+        IList<ReadOnlyMemory<float>> embeddings = await this._embeddingGenerator
             .GenerateEmbeddingsAsync(new List<string> { text }).ConfigureAwait(false);
         if (embeddings.Count == 0)
         {

--- a/dotnet/CoreLib/Text/ReadOnlyMemoryConverter.cs
+++ b/dotnet/CoreLib/Text/ReadOnlyMemoryConverter.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 
 using System;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.SemanticMemory.MemoryStorage.Qdrant.Client;
+namespace Microsoft.SemanticMemory.Text;
 
 internal sealed class ReadOnlyMemoryConverter : JsonConverter<ReadOnlyMemory<float>>
 {

--- a/examples/102-using-azure-cognitive-search/Program.cs
+++ b/examples/102-using-azure-cognitive-search/Program.cs
@@ -20,7 +20,6 @@ using Azure.Search.Documents;
 using Azure.Search.Documents.Indexes;
 using Azure.Search.Documents.Indexes.Models;
 using Azure.Search.Documents.Models;
-using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticMemory;
 using Microsoft.SemanticMemory.MemoryStorage;
 using Microsoft.SemanticMemory.MemoryStorage.AzureCognitiveSearch;
@@ -62,7 +61,7 @@ public static class Program
                 { "category", "search" },
                 { "year", "2024" },
             },
-            embedding: new Embedding<float>(new[] { 0f, 0.5f, 1 }));
+            embedding: new ReadOnlyMemory<float>(new[] { 0f, 0.5f, 1 }));
 
         var recordId2 = await InsertRecordAsync(Index,
             externalId: ExternalRecordId2,
@@ -74,7 +73,7 @@ public static class Program
                 { "category", "search" },
                 { "year", "2023" },
             },
-            embedding: new Embedding<float>(new[] { 0f, 0.5f, 1 }));
+            embedding: new ReadOnlyMemory<float>(new[] { 0f, 0.5f, 1 }));
 
         await Task.Delay(TimeSpan.FromSeconds(2));
 
@@ -174,7 +173,7 @@ public static class Program
 
     // ===============================================================================================
     private static async Task<string> InsertRecordAsync(string index,
-        string externalId, Dictionary<string, object> payload, TagCollection tags, Embedding<float> embedding)
+        string externalId, Dictionary<string, object> payload, TagCollection tags, ReadOnlyMemory<float> embedding)
     {
         Console.WriteLine("\n== INSERT ==\n");
         var client = s_adminClient.GetSearchClient(index);

--- a/examples/103-using-qdrant/Program.cs
+++ b/examples/103-using-qdrant/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticMemory;
 using Microsoft.SemanticMemory.MemoryStorage;
 using Microsoft.SemanticMemory.MemoryStorage.Qdrant;
@@ -26,7 +25,7 @@ Console.WriteLine("===== INSERT RECORD 1 =====");
 var memoryRecord1 = new MemoryRecord
 {
     Id = "memory 1",
-    Vector = new Embedding<float>(new[] { 0f, 0, 1, 0, 1 }),
+    Vector = new ReadOnlyMemory<float>(new[] { 0f, 0, 1, 0, 1 }),
     Tags = new TagCollection { { "updated", "no" }, { "type", "email" } },
     Payload = new Dictionary<string, object>()
 };
@@ -39,7 +38,7 @@ Console.WriteLine("===== INSERT RECORD 2 =====");
 var memoryRecord2 = new MemoryRecord
 {
     Id = "memory two",
-    Vector = new Embedding<float>(new[] { 0f, 0, 1, 0, 1 }),
+    Vector = new ReadOnlyMemory<float>(new[] { 0f, 0, 1, 0, 1 }),
     Tags = new TagCollection { { "type", "news" } },
     Payload = new Dictionary<string, object>()
 };
@@ -54,18 +53,18 @@ Console.WriteLine($"Update 2: {id2} {memoryRecord2.Id}");
 
 Console.WriteLine("===== SEARCH 1 =====");
 
-var similarList = memory.GetSimilarListAsync("test", new Embedding<float>(new[] { 0f, 0, 1, 0, 1 }),
+var similarList = memory.GetSimilarListAsync("test", new ReadOnlyMemory<float>(new[] { 0f, 0, 1, 0, 1 }),
     limit: 10, withEmbeddings: true);
 await foreach ((MemoryRecord, double) record in similarList)
 {
     Console.WriteLine(record.Item1.Id);
     Console.WriteLine("  tags: " + record.Item1.Tags.Count);
-    Console.WriteLine("  size: " + record.Item1.Vector.Count);
+    Console.WriteLine("  size: " + record.Item1.Vector.Length);
 }
 
 Console.WriteLine("===== SEARCH 2 =====");
 
-similarList = memory.GetSimilarListAsync("test", new Embedding<float>(new[] { 0f, 0, 1, 0, 1 }),
+similarList = memory.GetSimilarListAsync("test", new ReadOnlyMemory<float>(new[] { 0f, 0, 1, 0, 1 }),
     limit: 10, withEmbeddings: true, filter: new MemoryFilter().ByTag("type", "email"));
 await foreach ((MemoryRecord, double) record in similarList)
 {

--- a/examples/200-dotnet-nl2sql/nl2sql.console/KernelFactory.cs
+++ b/examples/200-dotnet-nl2sql/nl2sql.console/KernelFactory.cs
@@ -42,7 +42,7 @@ internal static class KernelFactory
 
         IKernel CreateKernel(IServiceProvider provider)
         {
-            var logger = provider.GetService<ILogger<IKernel>>();
+            var loggerFactory = provider.GetService<ILoggerFactory>();
 
             var apikey = configuration.GetValue<string>(SettingNameAzureApiKey);
             if (!string.IsNullOrWhiteSpace(apikey))
@@ -53,7 +53,7 @@ internal static class KernelFactory
                 var modelCompletion = configuration.GetValue<string>(SettingNameAzureModelCompletion);
                 var modelEmbedding = configuration.GetValue<string>(SettingNameAzureModelEmbedding);
 
-                return ConfigureAzure(endpoint, apikey, modelCompletion, modelEmbedding, logger).Build();
+                return ConfigureAzure(endpoint, apikey, modelCompletion, modelEmbedding, loggerFactory).Build();
             }
 
             apikey = configuration.GetValue<string>(SettingNameOpenAIApiKey);
@@ -62,7 +62,7 @@ internal static class KernelFactory
                 var modelCompletion = configuration.GetValue<string>(SettingNameOpenAIModelCompletion);
                 var modelEmbedding = configuration.GetValue<string>(SettingNameOpenAIModelEmbedding);
 
-                return ConfigureOpenAI(apikey, modelCompletion, modelEmbedding, logger).Build();
+                return ConfigureOpenAI(apikey, modelCompletion, modelEmbedding, loggerFactory).Build();
             }
 
             throw new InvalidDataException($"No api-key configured in {SettingNameAzureApiKey} or {SettingNameOpenAIApiKey}.");
@@ -73,13 +73,13 @@ internal static class KernelFactory
         string apikey,
         string? modelCompletion,
         string? modelEmbedding,
-        ILogger<IKernel>? logger)
+        ILoggerFactory? loggerFactory)
     {
         var builder = new KernelBuilder();
 
-        if (logger != null)
+        if (loggerFactory != null)
         {
-            builder.WithLogger(logger);
+            builder.WithLoggerFactory(loggerFactory);
         }
 
         modelCompletion ??= DefaultChatModel;
@@ -102,13 +102,13 @@ internal static class KernelFactory
         string apikey,
         string? modelCompletion,
         string? modelEmbedding,
-        ILogger<IKernel>? logger)
+        ILoggerFactory? loggerFactory)
     {
         var builder = new KernelBuilder();
 
-        if (logger != null)
+        if (loggerFactory != null)
         {
-            builder.WithLogger(logger);
+            builder.WithLoggerFactory(loggerFactory);
         }
 
         modelCompletion ??= DefaultChatModel;

--- a/examples/200-dotnet-nl2sql/nl2sql.library/Nl2Sql.Library.csproj
+++ b/examples/200-dotnet-nl2sql/nl2sql.library/Nl2Sql.Library.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="0.19.230804.2-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="0.21.230828.2-preview" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 

--- a/tests/FunctionalTests/VectorDbComparison/TestCosineSimilarity.cs
+++ b/tests/FunctionalTests/VectorDbComparison/TestCosineSimilarity.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using Microsoft.SemanticKernel.AI.Embeddings;
 using Microsoft.SemanticMemory;
 using Microsoft.SemanticMemory.MemoryStorage;
 using Microsoft.SemanticMemory.MemoryStorage.AzureCognitiveSearch;
@@ -52,10 +51,10 @@ public class TestCosineSimilarity
 
         var records = new Dictionary<string, MemoryRecord>
         {
-            ["01"] = new() { Id = "01", Vector = new Embedding<float>(new List<float> { 0.1f, 0.1f, 0.1f }) },
-            ["02"] = new() { Id = "02", Vector = new Embedding<float>(new List<float> { 0.81f, 0.12f, 0.13f }) },
-            ["03"] = new() { Id = "03", Vector = new Embedding<float>(new List<float> { 0.25f, 0.25f, 0.35f }) },
-            ["04"] = new() { Id = "04", Vector = new Embedding<float>(new List<float> { 0.05f, 0.91f, 0.03f }) },
+            ["01"] = new() { Id = "01", Vector = new ReadOnlyMemory<float>(new[] { 0.1f, 0.1f, 0.1f }) },
+            ["02"] = new() { Id = "02", Vector = new ReadOnlyMemory<float>(new[] { 0.81f, 0.12f, 0.13f }) },
+            ["03"] = new() { Id = "03", Vector = new ReadOnlyMemory<float>(new[] { 0.25f, 0.25f, 0.35f }) },
+            ["04"] = new() { Id = "04", Vector = new ReadOnlyMemory<float>(new[] { 0.05f, 0.91f, 0.03f }) },
         };
 
         foreach (KeyValuePair<string, MemoryRecord> r in records)
@@ -67,7 +66,7 @@ public class TestCosineSimilarity
 
         await Task.Delay(TimeSpan.FromSeconds(2));
 
-        var target = new Embedding<float>(new[] { 0.01f, 0.5f, 0.01f });
+        var target = new ReadOnlyMemory<float>(new[] { 0.01f, 0.5f, 0.01f });
         IAsyncEnumerable<(MemoryRecord, double)> acsList = acs.GetSimilarListAsync(indexName, target, 10, withEmbeddings: true);
         IAsyncEnumerable<(MemoryRecord, double)> qdrantList = qdrant.GetSimilarListAsync(indexName, target, 10, withEmbeddings: true);
         IAsyncEnumerable<(MemoryRecord, double)> simpleVecDbList = simpleVecDb.GetSimilarListAsync(indexName, target, 10, withEmbeddings: true);
@@ -79,19 +78,19 @@ public class TestCosineSimilarity
         this._log.WriteLine($"Azure Cognitive Search: {acsResults.Count} results");
         foreach ((MemoryRecord, double) r in acsResults)
         {
-            this._log.WriteLine($" - ID: {r.Item1.Id}, Distance: {r.Item2}, Expected distance: {CosineSim(target.Vector, records[r.Item1.Id].Vector.Vector)}");
+            this._log.WriteLine($" - ID: {r.Item1.Id}, Distance: {r.Item2}, Expected distance: {CosineSim(target.ToArray(), records[r.Item1.Id].Vector.ToArray())}");
         }
 
         this._log.WriteLine($"\n\nQdrant: {qdrantResults.Count} results");
         foreach ((MemoryRecord, double) r in qdrantResults)
         {
-            this._log.WriteLine($" - ID: {r.Item1.Id}, Distance: {r.Item2}, Expected distance: {CosineSim(target.Vector, records[r.Item1.Id].Vector.Vector)}");
+            this._log.WriteLine($" - ID: {r.Item1.Id}, Distance: {r.Item2}, Expected distance: {CosineSim(target.ToArray(), records[r.Item1.Id].Vector.ToArray())}");
         }
 
         this._log.WriteLine($"\n\nSimple vector DB: {simpleVecDbResults.Count} results");
         foreach ((MemoryRecord, double) r in simpleVecDbResults)
         {
-            this._log.WriteLine($" - ID: {r.Item1.Id}, Distance: {r.Item2}, Expected distance: {CosineSim(target.Vector, records[r.Item1.Id].Vector.Vector)}");
+            this._log.WriteLine($" - ID: {r.Item1.Id}, Distance: {r.Item2}, Expected distance: {CosineSim(target.ToArray(), records[r.Item1.Id].Vector.ToArray())}");
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)

The latest versions of Semantic Kernel have breaking changes which prevents consumers from updating past the version Semantic Memory targets. This changes updates the Semantic Kernel version and fixes associated regressions.

## High level description (Approach, Design)

- Update Semantic Kernel dependency to [0.21.230828.2-preview](https://www.nuget.org/packages/Microsoft.SemanticKernel/0.21.230828.2-preview).
- Fix `Embedding` -> `ReadOnlyMemorySpan` and `ILogger` -> `ILoggerFactory` regressions
- Refactor `ReadOnlyMemoryConverter` to a shared location