### PR TITLE
Expose app from MemoryClientBuilder

### DIFF
--- a/dotnet/CoreLib/AppBuilders/MemoryClientBuilder.cs
+++ b/dotnet/CoreLib/AppBuilders/MemoryClientBuilder.cs
@@ -53,6 +53,8 @@ public class MemoryClientBuilder
         get => this._appBuilder.Services;
     }
 
+    public WebApplication? App => this._app;
+
     public MemoryClientBuilder(IServiceCollection? sharedServiceCollection = null)
     {
         this._sharedServiceCollection = sharedServiceCollection;
@@ -83,6 +85,7 @@ public class MemoryClientBuilder
         // Default configuration for tests and demos
         this.WithDefaultMimeTypeDetection();
         this.WithSimpleFileStorage(new SimpleFileStorageConfig { Directory = Path.Join(Path.GetTempPath(), "content") });
+        this.WithSimpleVectorDb(new SimpleVectorDbConfig { Directory = Path.Join(Path.GetTempPath(), "vector-db") });
     }
 
     public MemoryClientBuilder WithoutDefaultHandlers()

--- a/dotnet/Service/Program.cs
+++ b/dotnet/Service/Program.cs
@@ -38,11 +38,12 @@ appBuilder.Services.AddSwaggerGen();
 
 // Inject memory client and its dependencies
 // Note: pass the current service collection to the builder, in order to start the pipeline handlers
-ISemanticMemoryClient memory = new MemoryClientBuilder(appBuilder.Services).FromAppSettings().Build();
+var memoryClientBuilder = new MemoryClientBuilder(appBuilder).FromAppSettings();
+var memory = memoryClientBuilder.Build();
 appBuilder.Services.AddSingleton(memory);
 
 // Build .NET web app as usual
-var app = appBuilder.Build();
+var app = memoryClientBuilder.App ?? throw new InvalidOperationException("Unable to retrieve app");
 
 // Read the settings, needed below
 var config = app.Configuration.GetSection("SemanticMemory").Get<SemanticMemoryConfig>() ?? throw new ConfigurationException("Unable to load configuration");


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
When deploying the service to web service which runs in IIS, we believe that we are experiencing the same issue detailed in this post: https://techcommunity.microsoft.com/t5/iis-support-blog/asp-net-core-503-server-has-been-shutdown/ba-p/3830338

## High level description (Approach, Design)
The MemoryClientBuilder builds a separate app or builds the app builder that's passed in. We expose the app property so that we can avoid having two apps.

