### PR TITLE
Azure Cognitive Search: cosine distance and cosine similarity

### DIFF
--- a/dotnet/CoreLib/AI/Embedding.cs
+++ b/dotnet/CoreLib/AI/Embedding.cs
@@ -53,6 +53,12 @@ public struct Embedding : IEquatable<Embedding>
         return this.Data.ToArray().CosineSimilarity(embedding.Data.ToArray());
     }
 
+    public double CosineDistance(Embedding embedding)
+    {
+        var similarity = this.Data.ToArray().CosineSimilarity(embedding.Data.ToArray());
+        return 1 / (2 - similarity);
+    }
+
     /// <summary>
     /// Convert Semantic Kernel data type
     /// </summary>

--- a/dotnet/CoreLib/MemoryStorage/AzureCognitiveSearch/AzureCognitiveSearchMemory.cs
+++ b/dotnet/CoreLib/MemoryStorage/AzureCognitiveSearch/AzureCognitiveSearchMemory.cs
@@ -157,13 +157,14 @@ public class AzureCognitiveSearchMemory : ISemanticMemoryVectorDb
 
         if (searchResult == null) { yield break; }
 
+        var minDistance = SimilarityToDistance(minRelevanceScore);
         await foreach (SearchResult<AzureCognitiveSearchMemoryRecord>? doc in searchResult.Value.GetResultsAsync())
         {
-            if (doc == null || doc.Score < minRelevanceScore) { continue; }
+            if (doc == null || doc.Score < minDistance) { continue; }
 
             MemoryRecord memoryRecord = doc.Document.ToMemoryRecord(withEmbeddings);
 
-            yield return (memoryRecord, doc.Score ?? 0);
+            yield return (memoryRecord, DistanceToSimilarity(doc.Score ?? 0));
         }
     }
 
@@ -558,6 +559,16 @@ public class AzureCognitiveSearchMemory : ISemanticMemoryVectorDb
         indexSchema.Fields.Add(vectorField);
 
         return indexSchema;
+    }
+
+    private static double DistanceToSimilarity(double distance)
+    {
+        return 1 - (1 - distance) / distance;
+    }
+
+    private static double SimilarityToDistance(double similarity)
+    {
+        return 1 / (2 - similarity);
     }
 
     #endregion

--- a/dotnet/CoreLib/MemoryStorage/ISemanticMemoryVectorDb.cs
+++ b/dotnet/CoreLib/MemoryStorage/ISemanticMemoryVectorDb.cs
@@ -58,7 +58,7 @@ public interface ISemanticMemoryVectorDb
     /// <param name="indexName">Index/Collection name</param>
     /// <param name="embedding">Target vector to compare to</param>
     /// <param name="limit">Max number of results</param>
-    /// <param name="minRelevanceScore">Minimum similarity required</param>
+    /// <param name="minRelevanceScore">Minimum Cosine Similarity required</param>
     /// <param name="filter">Values to match in the field used for tagging records (the field must be a list of strings)</param>
     /// <param name="withEmbeddings">Whether to include vector in the result</param>
     /// <param name="cancellationToken">Task cancellation token</param>

--- a/tests/FunctionalTests/VectorDbComparison/TestCosineSimilarity.cs
+++ b/tests/FunctionalTests/VectorDbComparison/TestCosineSimilarity.cs
@@ -80,19 +80,28 @@ public class TestCosineSimilarity
         this._log.WriteLine($"Azure Cognitive Search: {acsResults.Count} results");
         foreach ((MemoryRecord, double) r in acsResults)
         {
-            this._log.WriteLine($" - ID: {r.Item1.Id}, Distance: {r.Item2}, Expected distance: {CosineSim(target, records[r.Item1.Id].Vector)}");
+            var actual = r.Item2;
+            var expected = CosineSim(target, records[r.Item1.Id].Vector);
+            var diff = expected - actual;
+            this._log.WriteLine($" - ID: {r.Item1.Id}, Distance: {actual}, Expected distance: {expected}, Difference: {diff:0.0000000000}");
         }
 
         this._log.WriteLine($"\n\nQdrant: {qdrantResults.Count} results");
         foreach ((MemoryRecord, double) r in qdrantResults)
         {
-            this._log.WriteLine($" - ID: {r.Item1.Id}, Distance: {r.Item2}, Expected distance: {CosineSim(target, records[r.Item1.Id].Vector)}");
+            var actual = r.Item2;
+            var expected = CosineSim(target, records[r.Item1.Id].Vector);
+            var diff = expected - actual;
+            this._log.WriteLine($" - ID: {r.Item1.Id}, Distance: {actual}, Expected distance: {expected}, Difference: {diff:0.0000000000}");
         }
 
         this._log.WriteLine($"\n\nSimple vector DB: {simpleVecDbResults.Count} results");
         foreach ((MemoryRecord, double) r in simpleVecDbResults)
         {
-            this._log.WriteLine($" - ID: {r.Item1.Id}, Distance: {r.Item2}, Expected distance: {CosineSim(target, records[r.Item1.Id].Vector)}");
+            var actual = r.Item2;
+            var expected = CosineSim(target, records[r.Item1.Id].Vector);
+            var diff = expected - actual;
+            this._log.WriteLine($" - ID: {r.Item1.Id}, Distance: {actual}, Expected distance: {expected}, Difference: {diff:0.0000000000}");
         }
     }
 


### PR DESCRIPTION
When using vector search with `VectorMetricType.Cosine`, Azure Cognitive Search search result score is expressed as Cosine Distance. The value `minRelevanceScore` passed to `ISemanticMemoryVectorDb` is expressed as Cosine Similarity, so it's important to transform the values during the comparison and when returning results to users.

Formulas:

```csharp
double DistanceToSimilarity(double distance)
{
    return 1 - (1 - distance) / distance;
}

double SimilarityToDistance(double similarity)
{
    return 1 / (2 - similarity);
}
```
