### PR TITLE
Consider min relevance score in simple vector db

### DIFF
--- a/dotnet/CoreLib/MemoryStorage/DevTools/SimpleVectorDb.cs
+++ b/dotnet/CoreLib/MemoryStorage/DevTools/SimpleVectorDb.cs
@@ -77,7 +77,11 @@ public class SimpleVectorDb : ISemanticMemoryVectorDb
         }
 
         // Sort distances, from closest to most distant
-        IEnumerable<string> sorted = (from entry in distances orderby entry.Value descending select entry.Key);
+        IEnumerable<string> sorted =
+            from entry in distances
+            where entry.Value >= minRelevanceScore
+            orderby entry.Value descending
+            select entry.Key;
 
         // Return <count> vectors, including the calculated distance
         var count = 0;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)

The min relevance score was not taken into account in the simple vector db. This will cause the simple vector DB to return all records all the time.

## High level description (Approach, Design)

Consider min relevance score in simple vector db.
