### PR TITLE
Allow skip of summarize handler during client setup.

### DIFF
--- a/dotnet/CoreLib/AppBuilders/MemoryClientBuilder.cs
+++ b/dotnet/CoreLib/AppBuilders/MemoryClientBuilder.cs
@@ -71,6 +71,12 @@ public class MemoryClientBuilder
     /// </summary>
     private bool _useDefaultHandlers = true;
 
+    /// <summary>
+    /// Whether to register summarization along with the default handlers.
+    /// Ignored if _useDefaultHandlers is set to false.
+    /// </summary>
+    private bool _useSummarizeHandlers = true;
+
     public IServiceCollection Services
     {
         get => this._memoryServiceCollection;
@@ -103,6 +109,12 @@ public class MemoryClientBuilder
     public MemoryClientBuilder WithoutDefaultHandlers()
     {
         this._useDefaultHandlers = false;
+        return this;
+    }
+
+    public MemoryClientBuilder WithoutSummarizeHandlers()
+    {
+        this._useSummarizeHandlers = false;
         return this;
     }
 
@@ -468,8 +480,11 @@ public class MemoryClientBuilder
                 this._memoryServiceCollection.AddTransient<TextPartitioningHandler>(serviceProvider
                     => ActivatorUtilities.CreateInstance<TextPartitioningHandler>(serviceProvider, "partition"));
 
-                this._memoryServiceCollection.AddTransient<SummarizationHandler>(serviceProvider
+                if (this._useSummarizeHandlers)
+                {
+                    this._memoryServiceCollection.AddTransient<SummarizationHandler>(serviceProvider
                     => ActivatorUtilities.CreateInstance<SummarizationHandler>(serviceProvider, "summarize"));
+                }
 
                 this._memoryServiceCollection.AddTransient<GenerateEmbeddingsHandler>(serviceProvider
                     => ActivatorUtilities.CreateInstance<GenerateEmbeddingsHandler>(serviceProvider, "gen_embeddings"));
@@ -496,7 +511,10 @@ public class MemoryClientBuilder
             {
                 memoryClientInstance.AddHandler(serviceProvider.GetService<TextExtractionHandler>() ?? throw new ConfigurationException("Unable to build " + nameof(TextExtractionHandler)));
                 memoryClientInstance.AddHandler(serviceProvider.GetService<TextPartitioningHandler>() ?? throw new ConfigurationException("Unable to build " + nameof(TextPartitioningHandler)));
-                memoryClientInstance.AddHandler(serviceProvider.GetService<SummarizationHandler>() ?? throw new ConfigurationException("Unable to build " + nameof(SummarizationHandler)));
+                if (this._useSummarizeHandlers)
+                {
+                    memoryClientInstance.AddHandler(serviceProvider.GetService<SummarizationHandler>() ?? throw new ConfigurationException("Unable to build " + nameof(SummarizationHandler)));
+                }
                 memoryClientInstance.AddHandler(serviceProvider.GetService<GenerateEmbeddingsHandler>() ?? throw new ConfigurationException("Unable to build " + nameof(GenerateEmbeddingsHandler)));
                 memoryClientInstance.AddHandler(serviceProvider.GetService<SaveEmbeddingsHandler>() ?? throw new ConfigurationException("Unable to build " + nameof(SaveEmbeddingsHandler)));
                 memoryClientInstance.AddHandler(serviceProvider.GetService<DeleteDocumentHandler>() ?? throw new ConfigurationException("Unable to build " + nameof(DeleteDocumentHandler)));
@@ -537,7 +555,10 @@ public class MemoryClientBuilder
             // Handlers - Register these handlers to run as hosted services in the caller app.
             // At start each hosted handler calls IPipelineOrchestrator.AddHandlerAsync() to register in the orchestrator.
             this._hostServiceCollection.AddHandlerAsHostedService<TextExtractionHandler>("extract");
-            this._hostServiceCollection.AddHandlerAsHostedService<SummarizationHandler>("summarize");
+            if (this._useSummarizeHandlers)
+            {
+                this._hostServiceCollection.AddHandlerAsHostedService<SummarizationHandler>("summarize");
+            }
             this._hostServiceCollection.AddHandlerAsHostedService<TextPartitioningHandler>("partition");
             this._hostServiceCollection.AddHandlerAsHostedService<GenerateEmbeddingsHandler>("gen_embeddings");
             this._hostServiceCollection.AddHandlerAsHostedService<SaveEmbeddingsHandler>("save_embeddings");

--- a/dotnet/CoreLib/AppBuilders/MemoryClientBuilder.cs
+++ b/dotnet/CoreLib/AppBuilders/MemoryClientBuilder.cs
@@ -483,7 +483,7 @@ public class MemoryClientBuilder
                 if (this._useSummarizeHandlers)
                 {
                     this._memoryServiceCollection.AddTransient<SummarizationHandler>(serviceProvider
-                    => ActivatorUtilities.CreateInstance<SummarizationHandler>(serviceProvider, "summarize"));
+                        => ActivatorUtilities.CreateInstance<SummarizationHandler>(serviceProvider, "summarize"));
                 }
 
                 this._memoryServiceCollection.AddTransient<GenerateEmbeddingsHandler>(serviceProvider


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
We are seeing cases where the document summarization is being provided instead of the relevant chunk:

```
0.79480314 {"file":"Building 34_35 Orientation.pdf","emb_src_file":"Building 34_35 Orientation.pdf.summarize.0.txt"
0.7932581 {"file":"Building 34_35 Orientation.pdf","emb_src_file":"Building 34_35 Orientation.pdf.partition.1.txt"
0.78576535 {"file":"Building 34_35 Orientation.pdf","emb_src_file":"Building 34_35 Orientation.pdf.partition.0.txt"
```

## High level description (Approach, Design)
Chat-Copilot would like the option to *not* introduce the document summary until we can explore the feature further.  At this point it only servers to create an additional false-positive target with zero to none added value.