### PR TITLE
Fix CPM errors

### DIFF
--- a/dotnet/CoreLib/CoreLib.csproj
+++ b/dotnet/CoreLib/CoreLib.csproj
@@ -34,7 +34,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SemanticKernel" Version="0.24.230918.1-preview">
+        <PackageReference Include="Microsoft.SemanticKernel" VersionOverride="0.24.230918.1-preview">
             <PrivateAssets>none</PrivateAssets>
             <IncludeAssets>all</IncludeAssets>
         </PackageReference>

--- a/examples/101-using-core-nuget/101-using-core-nuget.csproj
+++ b/examples/101-using-core-nuget/101-using-core-nuget.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SemanticMemory.Core" Version="0.0.230827.2-preview" />
+        <PackageReference Include="Microsoft.SemanticMemory.Core" VersionOverride="0.0.230827.2-preview" />
     </ItemGroup>
 
     <!--    <ItemGroup>-->

--- a/examples/200-dotnet-nl2sql/nl2sql.library/Nl2Sql.Library.csproj
+++ b/examples/200-dotnet-nl2sql/nl2sql.library/Nl2Sql.Library.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Data.SqlClient" />
-        <PackageReference Include="Microsoft.SemanticKernel" Version="0.24.230918.1-preview"/>
+        <PackageReference Include="Microsoft.SemanticKernel" VersionOverride="0.24.230918.1-preview"/>
         <PackageReference Include="System.Linq.Async" />
     </ItemGroup>
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please provide the following information -->
## Motivation and Context (Why the change? What's the scenario?)
One of the last changes to #43 removed the CPM opt out which fixed warnings but introduced the error `error NU1008: Projects that use central package version management should not define the version on the PackageReference items but on the PackageVersion`.

## High level description (Approach, Design)
Add an explicit version override to project specific packages to fix CPM errors.