### PR TITLE
Only reference necessary SK packages

### DIFF
--- a/dotnet/CoreLib/CoreLib.csproj
+++ b/dotnet/CoreLib/CoreLib.csproj
@@ -34,7 +34,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SemanticKernel" VersionOverride="0.24.230918.1-preview">
+        <PackageReference Include="Microsoft.SemanticKernel.Core" VersionOverride="0.24.230918.1-preview">
+            <PrivateAssets>none</PrivateAssets>
+            <IncludeAssets>all</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.SemanticKernel.Connectors.AI.OpenAI" VersionOverride="0.24.230918.1-preview">
             <PrivateAssets>none</PrivateAssets>
             <IncludeAssets>all</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)
The `Microsoft.SemanticKernel` package currently includes dependencies on numerous other SK related packages for convenience (planners, retry, etc.). However, SM only uses a small subset of these. This leads to unnecessary dependencies when users add the SM package to their projects if they are selectively choosing different SK packages.

Note that `Nl2Sql.Library` is left alone to continue referencing the full SK package as it's an example scenario.

## High level description (Approach, Design)
This change removes the `Microsoft.SemanticKernel` reference and replaces it with references to `Microsoft.SemanticKernel.Core` and `Microsoft.SemanticKernel.Connectors.AI.OpenAI`, which are the only two required dependencies. In the future, SM can add more SK related packages as and when they are needed. This approach reduces unnecessary dependencies and makes the SM package more efficient for users.