### PR TITLE
Fix use of DefaultSteps from config file

### DIFF
--- a/dotnet/CoreLib/AppBuilders/MemoryClientBuilder.cs
+++ b/dotnet/CoreLib/AppBuilders/MemoryClientBuilder.cs
@@ -198,6 +198,9 @@ public class MemoryClientBuilder
         this._memoryConfiguration = config ?? throw new ConfigurationException("The given memory configuration is NULL");
         this._servicesConfiguration = servicesConfiguration ?? throw new ConfigurationException("The given service configuration is NULL");
 
+        // Required by ctors expecting SemanticMemoryConfig via DI
+        this.AddSingleton(this._memoryConfiguration);
+
         this.WithDefaultMimeTypeDetection();
 
         // Ingestion queue

--- a/dotnet/CoreLib/Configuration/SemanticMemoryConfig.cs
+++ b/dotnet/CoreLib/Configuration/SemanticMemoryConfig.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.SemanticMemory.Configuration;
 
@@ -56,16 +57,7 @@ public class SemanticMemoryConfig
         {
             return (this.DefaultSteps.Count > 0)
                 ? this.DefaultSteps
-                : new()
-                {
-                    "extract",
-                    "partition",
-                    "gen_embeddings",
-                    "save_embeddings",
-                    "summarize",
-                    "gen_embeddings",
-                    "save_embeddings"
-                };
+                : Constants.DefaultPipeline.ToList();
         }
     }
 

--- a/dotnet/Service/appsettings.json
+++ b/dotnet/Service/appsettings.json
@@ -34,14 +34,18 @@
       "VectorDbTypes": [
         "AzureCognitiveSearch"
       ],
+      // Note: keep the list empty in this file, to avoid unexpected merges
+      // with the list defined in appsettings.*.json.
+      // If the list is empty, SemanticMemoryConfig uses 'Constants.DefaultPipeline'.
       "DefaultSteps": [
-        "extract",
-        "partition",
-        "gen_embeddings",
-        "save_embeddings",
-        "summarize",
-        "gen_embeddings",
-        "save_embeddings"
+        // Default steps defined in 'Constants.DefaultPipeline'
+        // "extract",
+        // "partition",
+        // "gen_embeddings",
+        // "save_embeddings",
+        // "summarize",       // summarize after gen/save embeddings, because it can take long
+        // "gen_embeddings",  // gen embeddings for the summary
+        // "save_embeddings"  // save the summary embeddings
       ]
     },
     "Retrieval": {


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

The default pipeline steps defined in appsettings.*.json and appsettings.json were not properly loaded and propagated when using DI.
Fix for https://github.com/microsoft/semantic-memory/issues/64

## High level description (Approach, Design)

Fix: .NET IConfiguration doesn't support array override (when using multiple config sources): in fact arrays are merged so a shorter list in "appsettings.development.json" would not replace a longer list in "appsettings.json", but only replace the initial values. The list of default steps in appsettings.json is now empty, with defaults set via code. Values in appsettings.*.json now are properly loaded replacing the defaults.
SM config is also now stored in the service collection, so SemanticMemoryConfig can be injected via DI. Before the value passed by DI would be null, and the the pipeline orchestrator would not see settings from the config files (e.g. the list of default steps).

