### PR TITLE
Allow to share memory dependencies with external applications e.g. ASP.NET

### DIFF
--- a/dotnet/CoreLib/AppBuilders/ServiceCollectionPool.cs
+++ b/dotnet/CoreLib/AppBuilders/ServiceCollectionPool.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.SemanticMemory.AppBuilders;
+
+/// <summary>
+/// Represents a collection of service collections, so that DI helpers
+/// like `WithX` act on multiple service collections, e.g. the one used
+/// by MemoryClientBuilder and the one used by end user application.
+/// </summary>
+public class ServiceCollectionPool : IServiceCollection
+{
+    private readonly List<IServiceCollection> _pool;
+    private bool _locked;
+
+    public int Count => this._pool.First().Count;
+    public bool IsReadOnly => this._pool.First().IsReadOnly;
+
+    public ServiceCollectionPool(IServiceCollection sc)
+    {
+        this._locked = false;
+        this._pool = new List<IServiceCollection> { sc };
+    }
+
+    public void AddServiceCollection(IServiceCollection sc)
+    {
+        if (this._locked)
+        {
+            throw new InvalidOperationException("The pool of service collections is already in use and cannot be extended");
+        }
+
+        this._pool.Add(sc);
+    }
+
+    public void Add(ServiceDescriptor item)
+    {
+        this._locked = true;
+        foreach (var sc in this._pool)
+        {
+            sc.Add(item);
+        }
+    }
+
+    public bool Contains(ServiceDescriptor item)
+    {
+        this._locked = true;
+        return this._pool.First().Contains(item);
+    }
+
+    /**
+     * The methods below are not used by MemoryClientBuilder and could lead to
+     * unexpected bugs/behavior considering that the memory builder service
+     * collection is different from the end user application service collection.
+     */
+
+    #region unnecessary - risky for collections that could be different
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        throw new NotImplementedException();
+    }
+
+    public IEnumerator<ServiceDescriptor> GetEnumerator()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void CopyTo(ServiceDescriptor[] array, int arrayIndex)
+    {
+        throw new NotImplementedException();
+    }
+
+    public int IndexOf(ServiceDescriptor item)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Insert(int index, ServiceDescriptor item)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void RemoveAt(int index)
+    {
+        throw new NotImplementedException();
+    }
+
+    public ServiceDescriptor this[int index]
+    {
+        get
+        {
+            throw new NotImplementedException();
+        }
+        set
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public void Clear()
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool Remove(ServiceDescriptor item)
+    {
+        throw new NotImplementedException();
+    }
+
+    #endregion
+}

--- a/examples/007-aspnet-mvc-integration/007-aspnet-mvc-integration.csproj
+++ b/examples/007-aspnet-mvc-integration/007-aspnet-mvc-integration.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
+        <NoWarn>CS8625,CA1050</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/examples/007-aspnet-mvc-integration/Controllers/MemoryController.cs
+++ b/examples/007-aspnet-mvc-integration/Controllers/MemoryController.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.SemanticMemory;
+using Microsoft.SemanticMemory.DataFormats.Image;
 
 namespace Controllers;
 
@@ -10,15 +11,18 @@ namespace Controllers;
 public class MemoryController : ControllerBase
 {
     private readonly ISemanticMemoryClient _memory;
+    private readonly IOcrEngine _ocr;
 
-    public MemoryController(ISemanticMemoryClient memory)
+    public MemoryController(ISemanticMemoryClient memory, IOcrEngine ocr)
     {
         this._memory = memory;
+        this._ocr = ocr;
     }
 
     [HttpGet(Name = "GetAnswer")]
-    public async Task<MemoryAnswer> GetAsync()
+    public async Task<string> GetAsync()
     {
-        return await this._memory.AskAsync("What's Microsoft Copilot?");
+        var ocrResult = await this._ocr.ExtractTextFromImageAsync(null);
+        return ocrResult;
     }
 }

--- a/examples/007-aspnet-mvc-integration/MyOcrEngine.cs
+++ b/examples/007-aspnet-mvc-integration/MyOcrEngine.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.SemanticMemory.DataFormats.Image;
+
+public class MyOcrEngine : IOcrEngine
+{
+    public Task<string> ExtractTextFromImageAsync(Stream imageContent, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult("test");
+    }
+}

--- a/examples/007-aspnet-mvc-integration/Program.cs
+++ b/examples/007-aspnet-mvc-integration/Program.cs
@@ -12,9 +12,9 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 // === Memory stuff begin ===
-ISemanticMemoryClient memory = new MemoryClientBuilder()
+ISemanticMemoryClient memory = new MemoryClientBuilder(builder.Services)
     .FromAppSettings()
-    .WithOpenAIDefaults(Env.Var("OPENAI_API_KEY"))
+    .WithCustomImageOcr(new MyOcrEngine())
     .Build();
 
 builder.Services.AddSingleton(memory);

--- a/examples/007-aspnet-mvc-integration/Program.cs
+++ b/examples/007-aspnet-mvc-integration/Program.cs
@@ -12,11 +12,14 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 // === Memory stuff begin ===
+// * builder.Services is passed to the builder, so memory dependencies like the OCR service can be used also in our ASP.NET controllers
 ISemanticMemoryClient memory = new MemoryClientBuilder(builder.Services)
-    .FromAppSettings()
+    // .FromAppSettings()
+    .WithOpenAIDefaults(Env.Var("OPENAI_API_KEY"))
     .WithCustomImageOcr(new MyOcrEngine())
     .Build();
 
+// Add the memory to the ASP.NET services so our controllers can use it
 builder.Services.AddSingleton(memory);
 
 // === Memory stuff end ===

--- a/examples/007-aspnet-mvc-integration/appsettings.json
+++ b/examples/007-aspnet-mvc-integration/appsettings.json
@@ -7,6 +7,8 @@
     },
     // Store on files
     "ContentStorageType": "SimpleFileStorage",
+    // Generate content using OpenAI
+    "TextGeneratorType": "OpenAI",
     // How to ingest data
     "DataIngestion": {
       "OrchestrationType": "InProcess",


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

When an application like ASP.NET shares with the memory builder the local service collection, the user might want all the memory dependencies to be injected into it. 

E.g. methods like `WithCustomImageOcr` inject dependencies into the service collection used by the memory, but not the one used by the end user application:

```csharp

var builder = WebApplication.CreateBuilder(args);

ISemanticMemoryClient memory = new MemoryClientBuilder(builder.Services)
    .WithOpenAIDefaults(Env.Var("OPENAI_API_KEY"))
    .WithCustomImageOcr(new MyOcrEngine())
    .Build();
```

and a controller won't see the OCR engine, unless that is registered also in builder.Services

```csharp
[ApiController]
[Route("[controller]")]
public class MemoryController : ControllerBase
{
  private readonly IOcrEngine _ocr;

  public SomeController(IOcrEngine ocr)
  {
      this._ocr = ocr;
  }
}
```

## High level description (Approach, Design)

Add a new class to proxy `WithXYZ` calls to multiple service collection instances, e.g. the one used by the MemoryBuilder and the one used by ASP.NET and passed to the builder ctor.

