### PR TITLE
New API to delete indexes

### DIFF
--- a/dotnet/ClientLib/Constants.cs
+++ b/dotnet/ClientLib/Constants.cs
@@ -44,13 +44,16 @@ public static class Constants
     public const string HttpUploadEndpoint = "/upload";
     public const string HttpUploadStatusEndpoint = "/upload-status";
     public const string HttpDocumentsEndpoint = "/documents";
-    public const string HttpDeleteEndpointWithParams = $"{HttpDocumentsEndpoint}?{WebServiceIndexField}={HttpIndexPlaceholder}&{WebServiceDocumentIdField}={HttpDocumentIdPlaceholder}";
+    public const string HttpIndexesEndpoint = "/indexes";
+    public const string HttpDeleteDocumentEndpointWithParams = $"{HttpDocumentsEndpoint}?{WebServiceIndexField}={HttpIndexPlaceholder}&{WebServiceDocumentIdField}={HttpDocumentIdPlaceholder}";
+    public const string HttpDeleteIndexEndpointWithParams = $"{HttpIndexesEndpoint}?{WebServiceIndexField}={HttpIndexPlaceholder}";
     public const string HttpUploadStatusEndpointWithParams = $"{HttpUploadStatusEndpoint}?{WebServiceIndexField}={HttpIndexPlaceholder}&{WebServiceDocumentIdField}={HttpDocumentIdPlaceholder}";
     public const string HttpIndexPlaceholder = "{index}";
     public const string HttpDocumentIdPlaceholder = "{documentId}";
 
     // Handlers
     public const string DeleteDocumentPipelineStepName = "private_delete_document";
+    public const string DeleteIndexPipelineStepName = "private_delete_index";
 
     // Pipeline steps
     public static readonly string[] DefaultPipeline = { "extract", "partition", "gen_embeddings", "save_embeddings", "summarize", "gen_embeddings", "save_embeddings" };

--- a/dotnet/ClientLib/ISemanticMemoryClient.cs
+++ b/dotnet/ClientLib/ISemanticMemoryClient.cs
@@ -109,6 +109,15 @@ public interface ISemanticMemoryClient
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Delete an entire index.
+    /// </summary>
+    /// <param name="index">Optional index name, when empty the default index is deleted</param>
+    /// <param name="cancellationToken">Async task cancellation token</param>
+    public Task DeleteIndexAsync(
+        string? index = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Delete a specified document from memory, and update all derived memories.
     /// </summary>
     /// <param name="documentId">Document ID</param>

--- a/dotnet/ClientLib/MemoryWebClient.cs
+++ b/dotnet/ClientLib/MemoryWebClient.cs
@@ -124,6 +124,30 @@ public class MemoryWebClient : ISemanticMemoryClient
     }
 
     /// <inheritdoc />
+    public async Task DeleteIndexAsync(string? index = null, CancellationToken cancellationToken = default)
+    {
+        index = IndexExtensions.CleanName(index);
+        var url = Constants.HttpDeleteIndexEndpointWithParams
+            .Replace(Constants.HttpIndexPlaceholder, index);
+        HttpResponseMessage? response = await this._client.DeleteAsync(url, cancellationToken).ConfigureAwait(false);
+
+        // No error if the index doesn't exist
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return;
+        }
+
+        try
+        {
+            response.EnsureSuccessStatusCode();
+        }
+        catch (Exception e)
+        {
+            throw new SemanticMemoryException($"Index delete failed, status code: {response.StatusCode}", e);
+        }
+    }
+
+    /// <inheritdoc />
     public async Task DeleteDocumentAsync(string documentId, string? index = null, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(documentId))
@@ -132,7 +156,7 @@ public class MemoryWebClient : ISemanticMemoryClient
         }
 
         index = IndexExtensions.CleanName(index);
-        var url = Constants.HttpDeleteEndpointWithParams
+        var url = Constants.HttpDeleteDocumentEndpointWithParams
             .Replace(Constants.HttpIndexPlaceholder, index)
             .Replace(Constants.HttpDocumentIdPlaceholder, documentId);
         HttpResponseMessage? response = await this._client.DeleteAsync(url, cancellationToken).ConfigureAwait(false);
@@ -149,7 +173,7 @@ public class MemoryWebClient : ISemanticMemoryClient
         }
         catch (Exception e)
         {
-            throw new SemanticMemoryException($"Delete failed, status code: {response.StatusCode}", e);
+            throw new SemanticMemoryException($"Document deletion failed, status code: {response.StatusCode}", e);
         }
     }
 

--- a/dotnet/ClientLib/Models/DeleteAccepted.cs
+++ b/dotnet/ClientLib/Models/DeleteAccepted.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json.Serialization;
+
+#pragma warning disable IDE0130 // reduce number of "using" statements
+// ReSharper disable once CheckNamespace - reduce number of "using" statements
+namespace Microsoft.SemanticMemory;
+
+public class DeleteAccepted
+{
+    [JsonPropertyName("index")]
+    [JsonPropertyOrder(1)]
+    public string Index { get; set; } = string.Empty;
+
+    [JsonPropertyName("documentId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyOrder(2)]
+    public string? DocumentId { get; set; } = null;
+
+    [JsonPropertyName("message")]
+    [JsonPropertyOrder(3)]
+    public string Message { get; set; } = string.Empty;
+}

--- a/dotnet/CoreLib/AppBuilders/MemoryClientBuilder.cs
+++ b/dotnet/CoreLib/AppBuilders/MemoryClientBuilder.cs
@@ -488,6 +488,7 @@ public class MemoryClientBuilder
         {
             this.CompleteServerlessClient();
 
+            // Add handlers to DI service collection
             if (this._useDefaultHandlers)
             {
                 this._memoryServiceCollection.AddTransient<TextExtractionHandler>(serviceProvider
@@ -507,6 +508,9 @@ public class MemoryClientBuilder
 
                 this._memoryServiceCollection.AddTransient<DeleteDocumentHandler>(serviceProvider
                     => ActivatorUtilities.CreateInstance<DeleteDocumentHandler>(serviceProvider, Constants.DeleteDocumentPipelineStepName));
+
+                this._memoryServiceCollection.AddTransient<DeleteIndexHandler>(serviceProvider
+                    => ActivatorUtilities.CreateInstance<DeleteIndexHandler>(serviceProvider, Constants.DeleteIndexPipelineStepName));
             }
 
             var serviceProvider = this._memoryServiceCollection.BuildServiceProvider();
@@ -520,6 +524,7 @@ public class MemoryClientBuilder
 
             var memoryClientInstance = new Memory(orchestrator, searchClient);
 
+            // Load handlers in the memory client
             if (this._useDefaultHandlers)
             {
                 memoryClientInstance.AddHandler(serviceProvider.GetService<TextExtractionHandler>() ?? throw new ConfigurationException("Unable to build " + nameof(TextExtractionHandler)));
@@ -528,6 +533,7 @@ public class MemoryClientBuilder
                 memoryClientInstance.AddHandler(serviceProvider.GetService<GenerateEmbeddingsHandler>() ?? throw new ConfigurationException("Unable to build " + nameof(GenerateEmbeddingsHandler)));
                 memoryClientInstance.AddHandler(serviceProvider.GetService<SaveEmbeddingsHandler>() ?? throw new ConfigurationException("Unable to build " + nameof(SaveEmbeddingsHandler)));
                 memoryClientInstance.AddHandler(serviceProvider.GetService<DeleteDocumentHandler>() ?? throw new ConfigurationException("Unable to build " + nameof(DeleteDocumentHandler)));
+                memoryClientInstance.AddHandler(serviceProvider.GetService<DeleteIndexHandler>() ?? throw new ConfigurationException("Unable to build " + nameof(DeleteIndexHandler)));
             }
 
             return memoryClientInstance;
@@ -570,6 +576,7 @@ public class MemoryClientBuilder
             this._hostServiceCollection.AddHandlerAsHostedService<GenerateEmbeddingsHandler>("gen_embeddings");
             this._hostServiceCollection.AddHandlerAsHostedService<SaveEmbeddingsHandler>("save_embeddings");
             this._hostServiceCollection.AddHandlerAsHostedService<DeleteDocumentHandler>(Constants.DeleteDocumentPipelineStepName);
+            this._hostServiceCollection.AddHandlerAsHostedService<DeleteIndexHandler>(Constants.DeleteIndexPipelineStepName);
         }
 
         return new MemoryService(orchestrator, searchClient);

--- a/dotnet/CoreLib/ContentStorage/IContentStorage.cs
+++ b/dotnet/CoreLib/ContentStorage/IContentStorage.cs
@@ -10,7 +10,7 @@ namespace Microsoft.SemanticMemory.ContentStorage;
 public interface IContentStorage
 {
     /// <summary>
-    /// Create a new container, if it doesn't exist already
+    /// Create a new container (aka index), if it doesn't exist already
     /// </summary>
     /// <param name="index">Index name</param>
     /// <param name="cancellationToken">Async task cancellation token</param>
@@ -76,7 +76,27 @@ public interface IContentStorage
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Delete all artifacts of a document
+    /// Delete a container (aka index)
+    /// </summary>
+    /// <param name="index">Index name</param>
+    /// <param name="cancellationToken">Async task cancellation token</param>
+    Task DeleteIndexDirectoryAsync(
+        string index,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Delete all artifacts of a document, except for the status file
+    /// </summary>
+    /// <param name="index">Index name</param>
+    /// <param name="documentId">Document ID</param>
+    /// <param name="cancellationToken">Async task cancellation token</param>
+    Task EmptyDocumentDirectoryAsync(
+        string index,
+        string documentId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Delete all artifacts of a document, including status file and the containing folder
     /// </summary>
     /// <param name="index">Index name</param>
     /// <param name="documentId">Document ID</param>

--- a/dotnet/CoreLib/Diagnostics/Verify.cs
+++ b/dotnet/CoreLib/Diagnostics/Verify.cs
@@ -6,6 +6,14 @@ namespace Microsoft.SemanticMemory.Diagnostics;
 
 internal static class Verify
 {
+    public static void NotEmptyString(string value, string errMsg)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException(errMsg);
+        }
+    }
+
     public static void ValidateUrl(
         string url,
         bool requireHttps,

--- a/dotnet/CoreLib/Handlers/GenerateEmbeddingsHandler.cs
+++ b/dotnet/CoreLib/Handlers/GenerateEmbeddingsHandler.cs
@@ -54,7 +54,7 @@ public class GenerateEmbeddingsHandler : IPipelineStepHandler
     public async Task<(bool success, DataPipeline updatedPipeline)> InvokeAsync(
         DataPipeline pipeline, CancellationToken cancellationToken = default)
     {
-        this._log.LogTrace("Generating embeddings, pipeline {0}", pipeline.DocumentId);
+        this._log.LogDebug("Generating embeddings, pipeline '{0}/{1}'", pipeline.Index, pipeline.DocumentId);
 
         foreach (var uploadedFile in pipeline.Files)
         {

--- a/dotnet/CoreLib/Handlers/SaveEmbeddingsHandler.cs
+++ b/dotnet/CoreLib/Handlers/SaveEmbeddingsHandler.cs
@@ -48,8 +48,11 @@ public class SaveEmbeddingsHandler : IPipelineStepHandler
     }
 
     /// <inheritdoc />
-    public async Task<(bool success, DataPipeline updatedPipeline)> InvokeAsync(DataPipeline pipeline, CancellationToken cancellationToken = default)
+    public async Task<(bool success, DataPipeline updatedPipeline)> InvokeAsync(
+        DataPipeline pipeline, CancellationToken cancellationToken = default)
     {
+        this._log.LogDebug("Saving embeddings, pipeline '{0}/{1}'", pipeline.Index, pipeline.DocumentId);
+
         await this.DeletePreviousEmbeddingsAsync(pipeline, cancellationToken).ConfigureAwait(false);
         pipeline.PreviousExecutionsToPurge = new List<DataPipeline>();
 

--- a/dotnet/CoreLib/Handlers/SummarizationHandler.cs
+++ b/dotnet/CoreLib/Handlers/SummarizationHandler.cs
@@ -59,6 +59,8 @@ public class SummarizationHandler : IPipelineStepHandler
     public async Task<(bool success, DataPipeline updatedPipeline)> InvokeAsync(
         DataPipeline pipeline, CancellationToken cancellationToken = default)
     {
+        this._log.LogDebug("Generating summary, pipeline '{0}/{1}'", pipeline.Index, pipeline.DocumentId);
+
         foreach (DataPipeline.FileDetails uploadedFile in pipeline.Files)
         {
             // Track new files being generated (cannot edit originalFile.GeneratedFiles while looping it)

--- a/dotnet/CoreLib/Handlers/TextExtractionHandler.cs
+++ b/dotnet/CoreLib/Handlers/TextExtractionHandler.cs
@@ -54,6 +54,8 @@ public class TextExtractionHandler : IPipelineStepHandler
     public async Task<(bool success, DataPipeline updatedPipeline)> InvokeAsync(
         DataPipeline pipeline, CancellationToken cancellationToken = default)
     {
+        this._log.LogDebug("Extracting text, pipeline '{0}/{1}'", pipeline.Index, pipeline.DocumentId);
+
         foreach (DataPipeline.FileDetails uploadedFile in pipeline.Files)
         {
             if (uploadedFile.AlreadyProcessedBy(this))

--- a/dotnet/CoreLib/Handlers/TextPartitioningHandler.cs
+++ b/dotnet/CoreLib/Handlers/TextPartitioningHandler.cs
@@ -47,6 +47,8 @@ public class TextPartitioningHandler : IPipelineStepHandler
     public async Task<(bool success, DataPipeline updatedPipeline)> InvokeAsync(
         DataPipeline pipeline, CancellationToken cancellationToken = default)
     {
+        this._log.LogDebug("Partitioning text, pipeline '{0}/{1}'", pipeline.Index, pipeline.DocumentId);
+
         foreach (DataPipeline.FileDetails uploadedFile in pipeline.Files)
         {
             // Track new files being generated (cannot edit originalFile.GeneratedFiles while looping it)

--- a/dotnet/CoreLib/Memory.cs
+++ b/dotnet/CoreLib/Memory.cs
@@ -134,6 +134,12 @@ public class Memory : ISemanticMemoryClient
     }
 
     /// <inheritdoc />
+    public Task DeleteIndexAsync(string? index = null, CancellationToken cancellationToken = default)
+    {
+        return this._orchestrator.StartIndexDeletionAsync(index: index, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public Task DeleteDocumentAsync(string documentId, string? index = null, CancellationToken cancellationToken = default)
     {
         return this._orchestrator.StartDocumentDeletionAsync(documentId: documentId, index: index, cancellationToken);

--- a/dotnet/CoreLib/MemoryService.cs
+++ b/dotnet/CoreLib/MemoryService.cs
@@ -118,6 +118,12 @@ public class MemoryService : ISemanticMemoryClient
     }
 
     /// <inheritdoc />
+    public Task DeleteIndexAsync(string? index = null, CancellationToken cancellationToken = default)
+    {
+        return this._orchestrator.StartIndexDeletionAsync(index: index, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public Task DeleteDocumentAsync(string documentId, string? index = null, CancellationToken cancellationToken = default)
     {
         return this._orchestrator.StartDocumentDeletionAsync(documentId: documentId, index: index, cancellationToken);

--- a/dotnet/CoreLib/MemoryStorage/DevTools/ISimpleStorage.cs
+++ b/dotnet/CoreLib/MemoryStorage/DevTools/ISimpleStorage.cs
@@ -17,6 +17,7 @@ internal interface ISimpleStorage
     Task<string> ReadAsync(string collection, string id, CancellationToken cancellationToken = default);
     Task WriteAsync(string collection, string id, string data, CancellationToken cancellationToken = default);
     Task DeleteAsync(string collection, string id, CancellationToken cancellationToken = default);
+    Task DeleteCollectionAsync(string collection, CancellationToken cancellationToken = default);
     Task<Dictionary<string, string>> ReadAllAsync(string collection, CancellationToken cancellationToken = default);
 }
 
@@ -100,6 +101,22 @@ internal sealed class TextFileStorage : ISimpleStorage
         catch (Exception e)
         {
             this._log.LogError(e, "Text file storage deletion failed");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteCollectionAsync(string collection, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var collectionPath = this.BuildCollectionPath(collection);
+            this._log.LogDebug("Deleting collection {0}", collectionPath);
+            if (Directory.Exists(collectionPath)) { Directory.Delete(collectionPath, recursive: true); }
+        }
+        catch (Exception e)
+        {
+            this._log.LogError(e, "Collection deletion failed");
         }
 
         return Task.CompletedTask;
@@ -203,6 +220,13 @@ internal sealed class VolatileStorage : ISimpleStorage
                 this._data.Remove(collection);
             }
         }
+
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteCollectionAsync(string collection, CancellationToken cancellationToken = default)
+    {
+        this._data.Remove(collection);
 
         return Task.CompletedTask;
     }

--- a/dotnet/CoreLib/MemoryStorage/DevTools/SimpleVectorDb.cs
+++ b/dotnet/CoreLib/MemoryStorage/DevTools/SimpleVectorDb.cs
@@ -44,18 +44,6 @@ public class SimpleVectorDb : ISemanticMemoryVectorDb
     }
 
     /// <inheritdoc />
-    public async Task DeleteIndexAsync(string indexName, CancellationToken cancellationToken = default)
-    {
-        // Note: delete only vectors! If the folder contains other files
-        // the code will error out on purpose, to avoid data loss.
-        var list = this.GetListAsync(indexName, null, int.MaxValue, true, cancellationToken);
-        await foreach (MemoryRecord r in list.WithCancellation(cancellationToken))
-        {
-            await this.DeleteAsync(indexName, r, cancellationToken).ConfigureAwait(false);
-        }
-    }
-
-    /// <inheritdoc />
     public async Task<string> UpsertAsync(string indexName, MemoryRecord record, CancellationToken cancellationToken = default)
     {
         await this._storage.WriteAsync(indexName, record.Id, JsonSerializer.Serialize(record), cancellationToken).ConfigureAwait(false);
@@ -130,6 +118,12 @@ public class SimpleVectorDb : ISemanticMemoryVectorDb
                 yield return record;
             }
         }
+    }
+
+    /// <inheritdoc />
+    public Task DeleteIndexAsync(string indexName, CancellationToken cancellationToken = default)
+    {
+        return this._storage.DeleteCollectionAsync(indexName, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/dotnet/CoreLib/MemoryStorage/ISemanticMemoryVectorDb.cs
+++ b/dotnet/CoreLib/MemoryStorage/ISemanticMemoryVectorDb.cs
@@ -32,15 +32,6 @@ public interface ISemanticMemoryVectorDb
     //     CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Delete an index/collection
-    /// </summary>
-    /// <param name="indexName">Index/Collection name</param>
-    /// <param name="cancellationToken">Task cancellation token</param>
-    Task DeleteIndexAsync(
-        string indexName,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Insert/Update a vector + payload
     /// </summary>
     /// <param name="indexName">Index/Collection name</param>
@@ -87,6 +78,15 @@ public interface ISemanticMemoryVectorDb
         ICollection<MemoryFilter>? filters = null,
         int limit = 1,
         bool withEmbeddings = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Delete an index/collection
+    /// </summary>
+    /// <param name="indexName">Index/Collection name</param>
+    /// <param name="cancellationToken">Task cancellation token</param>
+    Task DeleteIndexAsync(
+        string indexName,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/dotnet/CoreLib/Pipeline/DistributedPipelineOrchestrator.cs
+++ b/dotnet/CoreLib/Pipeline/DistributedPipelineOrchestrator.cs
@@ -190,6 +190,8 @@ public class DistributedPipelineOrchestrator : BaseOrchestrator
 
             // Save the pipeline status. If this fails the system should retry the current step.
             await this.UpdatePipelineStatusAsync(pipeline, cancellationToken).ConfigureAwait(false);
+
+            await this.CleanUpAfterCompletionAsync(pipeline, cancellationToken).ConfigureAwait(false);
         }
         else
         {

--- a/dotnet/CoreLib/Pipeline/DistributedPipelineOrchestrator.cs
+++ b/dotnet/CoreLib/Pipeline/DistributedPipelineOrchestrator.cs
@@ -137,7 +137,7 @@ public class DistributedPipelineOrchestrator : BaseOrchestrator
         // In case the pipeline has no steps
         if (pipeline.Complete)
         {
-            this.Log.LogInformation("Pipeline {0} complete", pipeline.DocumentId);
+            this.Log.LogInformation("Pipeline '{0}/{1}' complete", pipeline.Index, pipeline.DocumentId);
             return;
         }
 
@@ -154,7 +154,7 @@ public class DistributedPipelineOrchestrator : BaseOrchestrator
         // In case the pipeline has no steps
         if (pipeline.Complete)
         {
-            this.Log.LogInformation("Pipeline {0} complete", pipeline.DocumentId);
+            this.Log.LogInformation("Pipeline '{0}/{1}' complete", pipeline.Index, pipeline.DocumentId);
             // Note: returning True, the message is removed from the queue
             return true;
         }
@@ -186,7 +186,7 @@ public class DistributedPipelineOrchestrator : BaseOrchestrator
     {
         if (pipeline.Complete)
         {
-            this.Log.LogInformation("Pipeline '{0}' complete", pipeline.DocumentId);
+            this.Log.LogInformation("Pipeline '{0}/{1}' complete", pipeline.Index, pipeline.DocumentId);
 
             // Save the pipeline status. If this fails the system should retry the current step.
             await this.UpdatePipelineStatusAsync(pipeline, cancellationToken).ConfigureAwait(false);
@@ -194,7 +194,7 @@ public class DistributedPipelineOrchestrator : BaseOrchestrator
         else
         {
             string nextStepName = pipeline.RemainingSteps.First();
-            this.Log.LogInformation("Enqueueing pipeline '{0}' step '{1}'", pipeline.DocumentId, nextStepName);
+            this.Log.LogInformation("Enqueueing pipeline '{0}/{1}' step '{2}'", pipeline.Index, pipeline.DocumentId, nextStepName);
 
             // Execute as much logic as possible before writing the new pipeline state to disk,
             // to reduce the chance of the persisted state to be out of sync.

--- a/dotnet/CoreLib/Pipeline/IPipelineOrchestrator.cs
+++ b/dotnet/CoreLib/Pipeline/IPipelineOrchestrator.cs
@@ -142,6 +142,15 @@ public interface IPipelineOrchestrator
     ITextGeneration GetTextGenerator();
 
     /// <summary>
+    /// Start an asynchronous job, via handlers, to delete a specified index
+    /// from vector and content storage. This might be a long running
+    /// operation, hence the use of queue/handlers.
+    /// </summary>
+    /// <param name="index">Optional index name</param>
+    /// <param name="cancellationToken">Async task cancellation token</param>
+    Task StartIndexDeletionAsync(string? index = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Start an asynchronous job, via handlers, to delete a specified document
     /// from memory, and update all derived memories. This might be a long running
     /// operation, hence the use of queue/handlers.

--- a/dotnet/CoreLib/Pipeline/InProcessPipelineOrchestrator.cs
+++ b/dotnet/CoreLib/Pipeline/InProcessPipelineOrchestrator.cs
@@ -125,19 +125,7 @@ public class InProcessPipelineOrchestrator : BaseOrchestrator
             }
         }
 
-        // If the pipeline asked to delete a document, there might be some files left over in the storage, such as the status file
-        // that we wish to delete to keep the storage clean. We try to delete what is left, ignoring exceptions.
-        if (pipeline.IsDocumentDeletionPipeline())
-        {
-            await this.TryToDeleteDocumentMetadataAsync(index: pipeline.Index, documentId: pipeline.DocumentId, cancellationToken).ConfigureAwait(false);
-        }
-
-        // If the pipeline asked to delete a document, there might be some files left over in the storage, such as the status file
-        // that we wish to delete to keep the storage clean. We try to delete what is left, ignoring exceptions.
-        if (pipeline.IsIndexDeletionPipeline())
-        {
-            await this.TryToDeleteIndexMetadataAsync(pipeline.Index, cancellationToken).ConfigureAwait(false);
-        }
+        await this.CleanUpAfterCompletionAsync(pipeline, cancellationToken).ConfigureAwait(false);
 
         this.Log.LogInformation("Pipeline '{0}/{1}' complete", pipeline.Index, pipeline.DocumentId);
     }

--- a/tests/FunctionalTests/ServerLess/IndexDeletionTest.cs
+++ b/tests/FunctionalTests/ServerLess/IndexDeletionTest.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+// ReSharper disable InconsistentNaming
+
+using FunctionalTests.TestHelpers;
+using Microsoft.SemanticMemory;
+using Microsoft.SemanticMemory.ContentStorage.DevTools;
+using Microsoft.SemanticMemory.MemoryStorage.DevTools;
+using Xunit.Abstractions;
+
+namespace FunctionalTests.ServerLess;
+
+public class IndexDeletionTest : BaseTestCase
+{
+    public IndexDeletionTest(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public async Task ItDeletesSimpleVectorDbIndexes()
+    {
+        // Arrange
+        var memory = new MemoryClientBuilder()
+            .WithOpenAIDefaults(Env.Var("OPENAI_API_KEY"))
+            .WithSimpleFileStorage(new SimpleFileStorageConfig { Directory = "tmp-files" })
+            .WithSimpleVectorDb(new SimpleVectorDbConfig { Directory = "tmp-vectors", StorageType = SimpleVectorDbConfig.StorageTypes.TextFile })
+            .BuildServerlessClient();
+
+        // Act
+        await memory.ImportTextAsync(
+            text: "this is a test",
+            documentId: "text1",
+            index: "index1",
+            steps: new[] { "extract", "partition", "gen_embeddings", "save_embeddings" });
+
+        await memory.ImportTextAsync(
+            text: "this is a test",
+            documentId: "text2",
+            index: "index1",
+            steps: new[] { "extract", "partition", "gen_embeddings", "save_embeddings" });
+
+        await memory.ImportTextAsync(
+            text: "this is a test",
+            documentId: "text3",
+            index: "index2",
+            steps: new[] { "extract", "partition", "gen_embeddings", "save_embeddings" });
+
+        await memory.ImportTextAsync(
+            text: "this is a test",
+            documentId: "text4",
+            index: "index2",
+            steps: new[] { "extract", "partition", "gen_embeddings", "save_embeddings" });
+
+        // Assert (no exception occurs, manual verification of folders being deleted)
+        await memory.DeleteDocumentAsync(documentId: "text1", index: "index1");
+        await memory.DeleteIndexAsync(index: "index2");
+    }
+
+    [Fact]
+    public async Task ItDeletesQdrantIndexes()
+    {
+        // Arrange
+        var memory = new MemoryClientBuilder()
+            .WithOpenAIDefaults(Env.Var("OPENAI_API_KEY"))
+            .WithSimpleFileStorage(new SimpleFileStorageConfig { Directory = "tmp-files" })
+            .WithQdrant("http://127.0.0.1:6333")
+            .BuildServerlessClient();
+
+        // Act
+        await memory.ImportTextAsync(
+            text: "this is a test",
+            documentId: "text1",
+            index: "index1",
+            steps: new[] { "extract", "partition", "gen_embeddings", "save_embeddings" });
+
+        await memory.ImportTextAsync(
+            text: "this is a test",
+            documentId: "text2",
+            index: "index1",
+            steps: new[] { "extract", "partition", "gen_embeddings", "save_embeddings" });
+
+        await memory.ImportTextAsync(
+            text: "this is a test",
+            documentId: "text3",
+            index: "index2",
+            steps: new[] { "extract", "partition", "gen_embeddings", "save_embeddings" });
+
+        await memory.ImportTextAsync(
+            text: "this is a test",
+            documentId: "text4",
+            index: "index2",
+            steps: new[] { "extract", "partition", "gen_embeddings", "save_embeddings" });
+
+        // Assert (no exception occurs, manual verification of collection being deleted)
+        await memory.DeleteDocumentAsync(documentId: "text1", index: "index1");
+        await memory.DeleteIndexAsync(index: "index2");
+    }
+}


### PR DESCRIPTION
## Motivation and Context (Why the change? What's the scenario?)

New API allowing apps to delete entire indexes.

## High level description (Approach, Design)

New API in `ISemanticMemoryClient` to delete indexes.
New HTTP method allowing to delete indexes.
New handler responsible for deleting vectors and files in storage.
New logic allowing a pipeline not having a document ID (just the index name to delete).
New logic to delete storage directories after a pipeline is complete and the status file has been written.
New functional tests (with manual verifications).
Fix OpenAPI signature of DELETE methods.

