### PR TITLE
Added user-agent header to WebScraper

### DIFF
--- a/dotnet/CoreLib/DataFormats/WebPages/WebScraper.cs
+++ b/dotnet/CoreLib/DataFormats/WebPages/WebScraper.cs
@@ -46,6 +46,7 @@ public class WebScraper
 
         // TODO: perf/TCP ports/reuse client
         using var client = new HttpClient();
+        client.DefaultRequestHeaders.UserAgent.ParseAdd(Telemetry.HttpUserAgent);
         HttpResponseMessage? response = await RetryLogic()
             .ExecuteAsync(async cancellationToken => await client.GetAsync(url, cancellationToken).ConfigureAwait(false))
             .ConfigureAwait(false);


### PR DESCRIPTION
This PR adds the Telemetry UserAgent constant to the Webscraper HttpClient. This should fix issue: https://github.com/microsoft/semantic-memory/issues/97

